### PR TITLE
add selection of element contents (e.g. text of current div) and its parent(s)

### DIFF
--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -537,7 +537,7 @@ WebView {
                     name: "cut"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Cut")
                     iconName: "edit-cut"
-                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable && (contextMenuRequest.editFlags & ContextMenuRequest.CanCut) && quickMenu.selectedTextLength > 0
+                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable && quickMenu.selectedTextLength > 0
                     visible: enabled
                     onTriggered: {
                        quickMenu.visible = false;
@@ -548,7 +548,7 @@ WebView {
                     name: "copy"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Copy")
                     iconName: "edit-copy"
-                    enabled: contextMenuRequest && (contextMenuRequest.editFlags & ContextMenuRequest.CanCopy) && quickMenu.selectedTextLength > 0
+                    enabled: contextMenuRequest && quickMenu.selectedTextLength > 0
                     visible: enabled
                     onTriggered: {
                         quickMenu.visible = false;

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -308,7 +308,7 @@ WebView {
         }
         Actions.Share {
             objectName: "ShareContextualAction"
-            enabled: ( browserTab.contentHandlerLoader && browserTab.contentHandlerLoader.status === Loader.Ready) &&
+            enabled: ( browserTab && browserTab.contentHandlerLoader && browserTab.contentHandlerLoader.status === Loader.Ready) &&
                       contextMenuRequest && contextMenuRequest.linkUrl.toString()
             onTriggered: {
                     //internal.shareLink(contextMenuRequest.linkUrl.toString(), contextMenuRequest.linkText)
@@ -581,7 +581,7 @@ WebView {
                     name: "share"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Share")
                     iconName: "share"
-                    enabled: ( browserTab.contentHandlerLoader && browserTab.contentHandlerLoader.status === Loader.Ready) &&
+                    enabled: ( browserTab && browserTab.contentHandlerLoader && browserTab.contentHandlerLoader.status === Loader.Ready) &&
                               contextMenuRequest && contextMenuRequest.selectedText
                     visible: enabled
                     onTriggered: {

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -521,7 +521,7 @@ WebView {
                     text: i18n.dtr('ubuntu-ui-toolkit', "Select All")
                     iconName: "edit-select-all"
                     // can we make it so that it only appears for non-empty inputs ?
-                    enabled: contextMenuRequest && (! contextMenuRequest.editFlags || (contextMenuRequest.editFlags & ContextMenuRequest.CanSelectAll))
+                    enabled: contextMenuRequest && (contextMenuRequest.editFlags & ContextMenuRequest.CanSelectAll)
                     visible: enabled
                     onTriggered: {
                         // in some cases this command creates a new contextMenuRequest, in others not
@@ -537,8 +537,7 @@ WebView {
                     name: "cut"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Cut")
                     iconName: "edit-cut"
-                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable &&
-                             (! contextMenuRequest.editFlags || (contextMenuRequest.editFlags & ContextMenuRequest.CanCut)) && quickMenu.selectedTextLength > 0
+                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable && (contextMenuRequest.editFlags & ContextMenuRequest.CanCut) && quickMenu.selectedTextLength > 0
                     visible: enabled
                     onTriggered: {
                        quickMenu.visible = false;
@@ -549,7 +548,7 @@ WebView {
                     name: "copy"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Copy")
                     iconName: "edit-copy"
-                    enabled: contextMenuRequest && (! contextMenuRequest.editFlags || (contextMenuRequest.editFlags & ContextMenuRequest.CanCopy)) && quickMenu.selectedTextLength > 0
+                    enabled: contextMenuRequest && (contextMenuRequest.editFlags & ContextMenuRequest.CanCopy) && quickMenu.selectedTextLength > 0
                     visible: enabled
                     onTriggered: {
                         quickMenu.visible = false;
@@ -560,7 +559,7 @@ WebView {
                     name: "paste"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Paste")
                     iconName: "edit-paste"
-                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable && (! contextMenuRequest.editFlags || (contextMenuRequest.editFlags & ContextMenuRequest.CanPaste))
+                    enabled: contextMenuRequest && contextMenuRequest.isContentEditable && (contextMenuRequest.editFlags & ContextMenuRequest.CanPaste)
                     visible: enabled
                     onTriggered: {
                         quickMenu.visible = false;


### PR DESCRIPTION
Currently if you long-press on a page, the current word gets selected, and the context menu offers "select all".
So you can either copy/share the word or the whole page. (for inputs/textareas it is better because you can select the text in that with "select all")
With this PR a new little feature "select element" is added, that allows to select the text / content of the element the context menu was opened in.

A typical use case for me is copying build / install instructions from a github / gitlab about page, and pasting them into the terminal app.
examples I've used for testing:
https://github.com/benni0815/SchafKopf
http://docs.ubports.com/en/latest/userguide/dailyuse/libertine.html

Another case would be selecting one paragraph in a text only.


