### PR TITLE
replace "Chromium" with "Chrome" (user agent)

### DIFF
--- a/src/Morph/Web/UserAgent02.qml
+++ b/src/Morph/Web/UserAgent02.qml
@@ -1,9 +1,9 @@
 /*
  * Copyright 2013-2016 Canonical Ltd.
  *
- * This file is part of webbrowser-app.
+ * This file is part of morph-browser.
  *
- * webbrowser-app is free software; you can redistribute it and/or modify
+ * morph-browser is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; version 3.
  *

--- a/src/Morph/Web/UserAgent02.qml
+++ b/src/Morph/Web/UserAgent02.qml
@@ -45,7 +45,7 @@ QtObject {
     //   virtually every single UA out there has, it seems unwise to remove it
     // note #2: "AppleWebKit", as opposed to plain "WebKit", does make a
     //   difference in the content served by certain sites (e.g. gmail.com)
-    readonly property string _template: "Mozilla/5.0 (Linux; Ubuntu %1%2%3) AppleWebKit/%4 Chromium/%5 %6Safari/%7%8"
+    readonly property string _template: "Mozilla/5.0 (Linux; Ubuntu %1%2%3) AppleWebKit/%4 Chrome/%5 %6Safari/%7%8"
 
     readonly property string _attributes: screenSize === "small" ? "like Android 4.4" : ""
 


### PR DESCRIPTION
Chromium seems unsupported browser for ReCaptcha

for https://github.com/ubports/morph-browser/issues/22

 if I use the original user agent (current ubports xenial branch), and change Chromium to Chrome, it works as well. But that's a bit against open source philosophy, isn't it ?

But seems like a workaround for now. Can the Chrome entry have negative side effects ? E.g. Sites thinking features are available that exist for Chrome but not Chromium ?