### PR TITLE
Move browser data on first start of unity8

### DIFF
--- a/debian/copy-browser-files.conf
+++ b/debian/copy-browser-files.conf
@@ -1,0 +1,19 @@
+description "Move browser-app files"
+author "Dalton Durst <dalton@ubports.com>"
+
+start on starting unity8
+
+script
+    set -x
+    SOURCE_DIR="$HOME/.local/share/webbrowser-app/"
+    DEST_DIR="$HOME/.local/share/morph-browser/"
+
+    if [ ! -d $DEST_DIR ]; then
+        echo ""
+        mkdir "$DEST_DIR"
+        cp "$SOURCE_DIR/bookmarks.sqlite" "$SOURCE_DIR/downloads.sqlite" "$SOURCE_DIR/history.sqlite" "$DEST_DIR"
+    else
+        echo "Destination exists, not copying browser files."
+    fi
+
+end script

--- a/debian/copy-browser-files.conf
+++ b/debian/copy-browser-files.conf
@@ -9,7 +9,6 @@ script
     DEST_DIR="$HOME/.local/share/morph-browser/"
 
     if [ ! -d $DEST_DIR ]; then
-        echo ""
         mkdir "$DEST_DIR"
         cp "$SOURCE_DIR/bookmarks.sqlite" "$SOURCE_DIR/downloads.sqlite" "$SOURCE_DIR/history.sqlite" "$DEST_DIR"
     else

--- a/debian/morph-browser.install
+++ b/debian/morph-browser.install
@@ -9,3 +9,4 @@ usr/share/locale/*/LC_MESSAGES/morph-browser.mo
 usr/share/url-dispatcher/
 usr/share/content-hub/peers/morph-browser
 debian/usr.bin.morph-browser etc/apparmor.d
+debian/copy-browser-files.conf usr/share/upstart/sessions/


### PR DESCRIPTION
This PR adds an Upstart job to move bookmarks, history, and downloads into morph-browser's directory on the start of unity8, if the `~/.local/share/morph-browser/`  directory doesn't exist.