### PR TITLE
change script run start, to completly hide scrollbar

### DIFF
--- a/src/Morph/Web/MorphWebContext.qml
+++ b/src/Morph/Web/MorphWebContext.qml
@@ -50,7 +50,7 @@ WebEngineProfile {
         },
         WebEngineScript {
             name: "oxide://scrollbar-theme/"
-            injectionPoint: WebEngineScript.Deferred
+            injectionPoint: WebEngineScript.DocumentCreation
             worldId: WebEngineScript.MainWorld
             sourceUrl: Qt.resolvedUrl("scrollbar-theme.js")
             runOnSubframes: true


### PR DESCRIPTION
there is an option to run the script on start, this should prevent short display of scrollbar https://github.com/ubports/morph-browser/issues/2