### PR TITLE
change APP_ID_DBUS and APP_PKGNAME_DBUS to morph_2dbrowser

### DIFF
--- a/debian/morph-browser-apparmor.manifest
+++ b/debian/morph-browser-apparmor.manifest
@@ -25,8 +25,8 @@
         "user-tmp"
       ],
       "template_variables": {
-        "APP_ID_DBUS": "webbrowser_2dapp",
-        "APP_PKGNAME_DBUS": "webbrowser_2dapp",
+        "APP_ID_DBUS": "morph_2dbrowser",
+        "APP_PKGNAME_DBUS": "morph_2dbrowser",
         "APP_PKGNAME": "morph-browser",
         "CLICK_DIR": "/usr/share/morph-browser"
       },

--- a/debian/morph-browser-apparmor.manifest
+++ b/debian/morph-browser-apparmor.manifest
@@ -4,7 +4,7 @@
       "binary": "/usr/bin/morph-browser",
       "profile_name": "morph-browser",
       "policy_vendor": "ubuntu",
-      "policy_version": 1.3,
+      "policy_version": 16.04,
       "policy_groups": [
         "accounts",
         "audio",


### PR DESCRIPTION
solution for https://github.com/ubports/morph-browser/issues/51
with that file upload and share works again (the _2d stands for the minus it seems)
question: 
In the same file there is also the policy version (1.3)
Should I change that to 16.04 ?
[edit: have changed it, please check if it is ok, since I only tested the DBUS id change]