### PR TITLE
handle certificate errors (CertificateVerificationDialog)

### DIFF
--- a/src/app/CertificateVerificationDialog.qml
+++ b/src/app/CertificateVerificationDialog.qml
@@ -23,18 +23,29 @@ import Ubuntu.Components.Popups 1.3 as Popups
 Popups.Dialog {
     title: i18n.tr("This connection is untrusted")
     // TRANSLATORS: %1 refers to the hostname
-    text: i18n.tr("You are trying to securely reach %1, but the security certificate of this website is not trusted.").arg(model.hostname)
+    text: i18n.tr("You are trying to securely reach %1, but the security certificate of this website is not trusted. Reason: %2").arg(host).arg(localizedErrorMessage)
+
+    property string host
+    property string localizedErrorMessage
+    property bool errorIsOverridable
+
+    signal accept()
+    signal reject()
+
+    onAccept: hide()
+    onReject: hide()
 
     Button {
         text: i18n.tr("Proceed anyway")
+        visible: errorIsOverridable
         color: theme.palette.normal.negative
-        onClicked: model.accept()
+        onClicked: accept()
     }
 
     Button {
         text: i18n.tr("Back to safety")
         color: theme.palette.normal.positive
-        onClicked: model.reject()
+        onClicked: reject()
     }
 
     Component.onCompleted: show()

--- a/src/app/UrlUtils.js
+++ b/src/app/UrlUtils.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+function extractScheme(url) {
+    var urlString = url.toString()
+    return urlString.substring(0,urlString.indexOf("://"))
+}
+
 function removeScheme(url) {
     var rest = url.toString()
     var indexOfScheme = rest.indexOf("://")

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -108,7 +108,7 @@ FocusScope {
 
             findInPageMode: findInPageMode
             findController: internal.webview ? internal.webview.findController : null
-            securityStatus: internal.webview ? internal.webview.securityStatus : null
+            certificateErrorsMap: internal.webview ? internal.webview.certificateErrorsMap : ({})
 
             anchors {
                 left: parent.left

--- a/src/app/webbrowser/SecurityCertificatePopover.qml
+++ b/src/app/webbrowser/SecurityCertificatePopover.qml
@@ -25,10 +25,11 @@ import Morph.Web 0.1
 Popover {
     id: certificatePopover
 
-    property var securityStatus
+    property var certificateError: null
+    property string host
 
-    readonly property bool isWarning: securityStatus.securityLevel == Oxide.SecurityStatus.SecurityLevelWarning
-    readonly property bool isError: securityStatus.securityLevel == Oxide.SecurityStatus.SecurityLevelError
+    property bool isWarning: false
+    readonly property bool isError:  (certificateError !== null)
 
     Column {
         width: parent.width - units.gu(4)
@@ -83,27 +84,9 @@ Popover {
                         wrapMode: Text.WordWrap
                         visible: certificatePopover.isError
                         fontSize: "x-small"
-                        text: {
-                            switch (securityStatus.certStatus) {
-                                case Oxide.SecurityStatus.CertStatusBadIdentity:
-                                    return i18n.tr("Server certificate does not match the identity of the site.")
-                                case Oxide.SecurityStatus.CertStatusExpired:
-                                    return i18n.tr("Server certificate has expired.")
-                                case Oxide.SecurityStatus.CertStatusDateInvalid:
-                                    return i18n.tr("Server certificate contains invalid dates.")
-                                case Oxide.SecurityStatus.CertStatusAuthorityInvalid:
-                                    return i18n.tr("Server certificate is issued by an entity that is not trusted.")
-                                case Oxide.SecurityStatus.CertStatusRevoked:
-                                    return i18n.tr("Server certificate has been revoked.")
-                                case Oxide.SecurityStatus.CertStatusInvalid:
-                                    return i18n.tr("Server certificate is invalid.")
-                                case Oxide.SecurityStatus.CertStatusInsecure:
-                                    return i18n.tr("Server certificate is insecure.")
-                                default:
-                                    return i18n.tr("Server certificate failed our security checks for an unknown reason.")
-                            }
-                        }
-                    }
+                        text: certificatePopover.certificateError ? certificatePopover.certificateError.description : ""
+                   }
+
                 }
             }
 
@@ -123,65 +106,7 @@ Popover {
             Label {
                 width: parent.width
                 wrapMode: Text.WordWrap
-                text: i18n.tr("You are connected to")
-                fontSize: "x-small"
-            }
-
-            Label {
-                width: parent.width
-                wrapMode: Text.WordWrap
-                text: securityStatus.certificate.subjectDisplayName
-                fontSize: "x-small"
-            }
-
-            ThinDivider {
-                width: parent.width
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                visible: orgName.visible || localityName.visible || stateName.visible || countryName.visible
-            }
-
-            Label {
-                width: parent.width
-                wrapMode: Text.WordWrap
-                visible: orgName.visible
-                text: i18n.tr("Which is run by")
-                fontSize: "x-small"
-            }
-
-            Label {
-                id: orgName
-                width: parent.width
-                wrapMode: Text.WordWrap
-                visible: text.length > 0
-                text: securityStatus.certificate.getSubjectInfo(Oxide.SslCertificate.PrincipalAttrOrganizationName).join(", ")
-                fontSize: "x-small"
-            }
-
-            Label {
-                id: localityName
-                width: parent.width
-                wrapMode: Text.WordWrap
-                visible: text.length > 0
-                text: securityStatus.certificate.getSubjectInfo(Oxide.SslCertificate.PrincipalAttrLocalityName).join(", ")
-                fontSize: "x-small"
-            }
-
-            Label {
-                id: stateName
-                width: parent.width
-                wrapMode: Text.WordWrap
-                visible: text.length > 0
-                text: securityStatus.certificate.getSubjectInfo(Oxide.SslCertificate.PrincipalAttrStateOrProvinceName).join(", ")
-                fontSize: "x-small"
-            }
-
-            Label {
-                id: countryName
-                width: parent.width
-                wrapMode: Text.WordWrap
-                visible: text.length > 0
-                text: securityStatus.certificate.getSubjectInfo(Oxide.SslCertificate.PrincipalAttrCountryName).join(", ")
+                text: i18n.tr("You are connected to %1 via HTTPS. The certificate is valid.".arg(host))
                 fontSize: "x-small"
             }
         }


### PR DESCRIPTION
display the broken lock for pages with certificate errors
correct the display of the lock symbol (only for https without certificate errors)
certificate popover contains the certificate error message

https://github.com/ubports/morph-browser/issues/70