### PR TITLE
move findController to WebViewImpl

### DIFF
--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -44,6 +44,8 @@ WebView {
     // better way to detect that, or move context menu items only available for the browser to other files ?
     readonly property bool isWebApp: (typeof browserTab === 'undefined')
 
+    readonly property alias findController: findController
+
     Component.onCompleted: {
         console.log(__ua.defaultUA);
         profile.httpUserAgent = __ua.defaultUA;
@@ -66,6 +68,25 @@ WebView {
         readonly property var downloadMimeTypesBlacklist: [
             "application/x-shockwave-flash", // http://launchpad.net/bugs/1379806
         ]
+    }
+
+      QtObject {
+        id: findController
+
+        property bool foundMatch: false
+        property string searchText: ""
+
+        function next() {
+                webview.findText(searchText, 0, function(success) {foundMatch = success})
+        }
+
+        function previous() {
+                webview.findText(searchText, WebEngineView.FindBackward, function(success) {foundMatch = success})
+        }
+
+        onSearchTextChanged: {
+                findController.next()
+        }
     }
 
     onJavaScriptDialogRequested: function(request) {

--- a/src/app/webbrowser/AddressBar.qml
+++ b/src/app/webbrowser/AddressBar.qml
@@ -64,6 +64,12 @@ FocusScope {
         textField.selectAll()
     }
 
+    Binding {
+        target: findController
+        property: "searchText"
+        value: findInPageMode ? textField.text : ""
+    }
+
     TextField {
         id: textField
         objectName: "addressBarTextField"
@@ -252,9 +258,9 @@ FocusScope {
             if (!findInPageMode) {
                 accepted()
             } else if (event.modifiers & Qt.ShiftModifier) {
-                findController.previous()
+                addressbar.findController.previous()
             } else {
-                findController.next()
+                addressbar.findController.next()
             }
         }
     }

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -1468,14 +1468,14 @@ BrowserView {
     Shortcut {
         sequence: StandardKey.FindNext
         enabled: currentWebview && chrome.findInPageMode
-        onActivated: chrome.findController.next()
+        onActivated: currentWebview.findController.next()
     }
 
     // Ctrl+Shift+G: Find previous
     Shortcut {
         sequence: StandardKey.FindPrevious
         enabled: currentWebview && chrome.findInPageMode
-        onActivated: chrome.findController.previous()
+        onActivated: currentWebview.findController.previous()
     }
 
     // Ctrl+Plus: zoom in

--- a/src/app/webbrowser/Chrome.qml
+++ b/src/app/webbrowser/Chrome.qml
@@ -36,7 +36,6 @@ ChromeBase {
     property alias requestedUrl: navigationBar.requestedUrl
     property alias canSimplifyText: navigationBar.canSimplifyText
     property alias findInPageMode: navigationBar.findInPageMode
-    property alias findController: navigationBar.findController
     property alias editing: navigationBar.editing
     property alias incognito: navigationBar.incognito
     property alias showTabsBar: tabsBar.active

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -35,7 +35,6 @@ FocusScope {
     property alias requestedUrl: addressbar.requestedUrl
     property alias canSimplifyText: addressbar.canSimplifyText
     property alias findInPageMode: addressbar.findInPageMode
-    property alias findController: addressbar.findController
     property alias editing: addressbar.editing
     property alias incognito: addressbar.incognito
     property alias showFaviconInAddressBar: addressbar.showFavicon
@@ -46,33 +45,6 @@ FocusScope {
 
     onFindInPageModeChanged: if (findInPageMode) addressbar.text = ""
     onIncognitoChanged: findInPageMode = false
-
-    onTextChanged: {
-        if (findInPageMode)
-        {
-            findController.next()
-        }
-    }
-
-    QtObject {
-        id: findController
-
-        property bool foundMatch
-
-        function next() {
-            if (internal.webview)
-            {
-                internal.webview.findText(addressbar.text, 0, function(success) {foundMatch = success})
-            }
-        }
-
-        function previous() {
-            if (internal.webview)
-            {
-                internal.webview.findText(addressbar.text, WebEngineView.FindBackward, function(success) {foundMatch = success})
-            }
-        }
-    }
 
     function selectAll() {
         addressbar.selectAll()
@@ -136,7 +108,7 @@ FocusScope {
             focus: true
 
             findInPageMode: findInPageMode
-            findController: findController
+            findController: internal.webview ? internal.webview.findController : null
             certificateErrorsMap: internal.webview ? internal.webview.certificateErrorsMap : ({})
 
             anchors {
@@ -193,8 +165,8 @@ FocusScope {
                 anchors.verticalCenter: parent.verticalCenter
 
                 visible: findInPageMode
-                enabled: findController.foundMatch
-                onTriggered: findController.previous()
+                enabled: internal.webview && internal.webview.findController && internal.webview.findController.foundMatch
+                onTriggered: internal.webview.findController.previous()
             }
 
             ChromeButton {
@@ -210,8 +182,8 @@ FocusScope {
                 anchors.verticalCenter: parent.verticalCenter
 
                 visible: findInPageMode
-                enabled: findController.foundMatch
-                onTriggered: findController.next()
+                enabled: internal.webview && internal.webview.findController && internal.webview.findController.foundMatch
+                onTriggered: internal.webview.findController.next()
             }
 
             ChromeButton {


### PR DESCRIPTION
the previous implementation worked in gerneral, but when switching tabs or when searching before loading was finished, the search for the current browser window was not reset properly. This one is closer to the original implementation.