### PR TITLE
for now restore the old behavior for webapp-container

### DIFF
--- a/src/app/webcontainer/WebViewImplOxide.qml
+++ b/src/app/webcontainer/WebViewImplOxide.qml
@@ -246,8 +246,18 @@ WebappWebview {
             return
         }
 
-        if (webview.shouldAllowNavigationTo(url))
+        // for now (as the old behavior) allow resources to be loaded
+        // ToDo: maybe we should only allow resources defined in the URL patterns here
+        if (! request.isMainFrame)
+        {
+            console.debug('accepted resource request to %1.'.arg(url))
             request.action = WebEngineNavigationRequest.AcceptRequest
+        }
+
+        else if (webview.shouldAllowNavigationTo(url))
+        {
+            request.action = WebEngineNavigationRequest.AcceptRequest
+        }
 
         // SAML requests are used for instance by Google Apps for your domain;
         // they are implemented as a HTTP redirect to a URL containing the
@@ -262,8 +272,16 @@ WebappWebview {
       //  }
 
       if (request.action === WebEngineNavigationRequest.IgnoreRequest) {
-            console.debug('Opening: %1 in the browser window.'.arg(url))
-            openUrlExternally(url, true)
+
+            if (request.isMainFrame)
+            {
+                console.debug('Opening: %1 in the browser window.'.arg(url))
+                openUrlExternally(url, true)
+            }
+            else
+            {
+                console.debug('ignored request of current page to %1.'.arg(url))
+            }
       }
     }
 


### PR DESCRIPTION
allow resource requests even if not defined in the url patterns

- opening ignored navigation requests in morph only makes sense if the are in the main frame (isMainFrame=true in https://doc.qt.io/qt-5/qml-qtwebengine-webenginenavigationrequest.html#isMainFrame-prop) so that clearly has to be corrected
- instead of that we could either ignore them entirely (requires defining them in the URL patterns or other app specific settings), or accept them

Ignoring them would add tracking protection for the webapps, but the browser itself would still load the requests. On the other hand it could break webapps that rely on the page being fully loaded including 3rd party URLs. For the user it would be so that the same page works in morph, but not in the webapp.