### PR TITLE
Use DuckDuckGo's Start page as default homepage

### DIFF
--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -283,7 +283,7 @@ QtObject {
     }
 
     property var settings: Settings {
-        property url homepage: "https://duckduckgo.com"
+        property url homepage: "https://start.duckduckgo.com"
         property string searchEngine: "duckduckgo"
         property bool restoreSession: true
         property bool setDesktopMode: false
@@ -292,7 +292,7 @@ QtObject {
         property string defaultVideoDevice: ""
 
         function restoreDefaults() {
-            homepage  = "https://duckduckgo.com"
+            homepage  = "https://start.duckduckgo.com"
             searchEngine = "duckduckgo"
             restoreSession = true
             setDesktopMode = false

--- a/tests/autopilot/webbrowser_app/tests/test_settings.py
+++ b/tests/autopilot/webbrowser_app/tests/test_settings.py
@@ -192,7 +192,7 @@ class TestSettings(StartOpenRemotePageTestCaseBase):
 
         homepage = settings.get_homepage_entry()
         self.assertThat(homepage.currentHomepage,
-                        Eventually(Equals("https://duckduckgo.com")))
+                        Eventually(Equals("https://start.duckduckgo.com")))
 
         restore_session = settings.get_restore_session_entry()
         checkbox = restore_session.select_single(uitk.CheckBox)


### PR DESCRIPTION
Previously we used duckduckgo.com, which gives handy tips to set the
site as your homepage and other similar prompts. Using
start.duckduckgo.com instead removes these prompts.