### PR TITLE
Variablize lowMemoryThreshold to keep tabs open

### DIFF
--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -433,12 +433,12 @@ QtObject {
         target: MemInfo
         onFreeChanged: {
             var freeMemRatio = (MemInfo.total > 0) ? (MemInfo.free / MemInfo.total) : 1.0
+            var lowMemoryThresholdPercent = 0.2;
             // Under that threshold, available memory is considered "low", and the
             // browser is going to try and free up memory from unused tabs. This
             // value was chosen empirically, it is subject to change to better
             // reflect what a system under memory pressure might look like.
-            var lowOnMemory = (freeMemRatio < 0.2)
-            if (lowOnMemory) {
+            if (freeMemRatio < lowMemoryThresholdPercent) {
                 // Unload an inactive tab to (hopefully) free up some memory
                 function getCandidate(model) {
                     // Naive implementation that only takes into account the


### PR DESCRIPTION
I've noticed that in morph-browser, the out-of-memory tab loader was a
bit excessive. For some reason, it would unload tabs even when the
system had lots of memory available -- 1GB or more!
Turns out, the `freeMemRatio < 0.2` test always returned true, no
matter what. I'm not sure why this happens, probably a QML+JS quirk.
By moving the low memory threshold into a new variable, the test
returns correctly based on the amount of available memory in the system.
No more unloading of every tab!

Fixes ubports/morph-browser#99