### PR TITLE
temporary input issue fix.

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -20,6 +20,7 @@ set(COMMONLIB webbrowser-common)
 set(COMMONLIB_SRC
     browserapplication.cpp
     favicon-fetcher.cpp
+    input-method-handler.cpp
     meminfo.cpp
     mime-database.cpp
     session-storage.cpp

--- a/src/app/browserapplication.cpp
+++ b/src/app/browserapplication.cpp
@@ -35,6 +35,7 @@
 #include "browserapplication.h"
 #include "config.h"
 #include "favicon-fetcher.h"
+#include "input-method-handler.h"
 #include "meminfo.h"
 #include "mime-database.h"
 #include "session-storage.h"
@@ -207,6 +208,9 @@ bool BrowserApplication::initialize(const QString& qmlFileSubPath
         }
     }
     QQmlProperty::write(m_object, QStringLiteral("hasTouchScreen"), hasTouchScreen);
+
+    inputMethodHandler * handler = new inputMethodHandler();
+    this->installEventFilter(handler);
 
     return true;
 }

--- a/src/app/input-method-handler.cpp
+++ b/src/app/input-method-handler.cpp
@@ -1,0 +1,48 @@
+#include "input-method-handler.h"
+
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QDebug>
+
+inputMethodHandler::inputMethodHandler(QObject *parent) : QObject(parent) {}
+
+bool inputMethodHandler::eventFilter(QObject* obj, QEvent* event)
+{
+    // only process input method related events
+    if (event->type() != QEvent::InputMethod)
+    {
+        return false;
+    }
+
+    // the text field objects in the browser do not have object names.
+    if (obj->objectName() != "")
+    {
+        return false;
+    }
+
+    //qDebug() << "input event, object is " << obj->objectName() << " is window ? " << obj->isWindowType() << " is widget ? " << obj->isWidgetType();;
+
+    // get info about the event
+    QInputMethodEvent * inputevent = static_cast<QInputMethodEvent*>(event);
+
+    //qDebug() << "input event, predit string: " << inputevent->preeditString() << " commit string: " << inputevent->commitString();
+    // check the request contains informatino about the text format
+    bool hasTextFormatInfo = false;
+
+    for (auto attribute : inputevent->attributes())
+    {
+      if (attribute.type == QInputMethodEvent::TextFormat)
+      {
+         //qDebug() << "text format found.";
+         hasTextFormatInfo = true;
+      }
+    }
+
+    // reset if there is no text format provided
+    if ( ! hasTextFormatInfo && QGuiApplication::inputMethod() )
+    {
+      QGuiApplication::inputMethod()->reset();
+    }
+
+    return false;
+}

--- a/src/app/input-method-handler.h
+++ b/src/app/input-method-handler.h
@@ -1,0 +1,19 @@
+#ifndef INPUTMETHODHANDLER_H
+#define INPUTMETHODHANDLER_H
+
+#include <QObject>
+#include <QEvent>
+#include <QKeyEvent>
+
+class inputMethodHandler : public QObject
+{
+// Q_OBJECT
+public:
+    explicit inputMethodHandler(QObject *parent = 0);
+
+public:
+    bool eventFilter(QObject* obj, QEvent* event);
+
+};
+
+#endif

--- a/src/app/webbrowser/searchengines/duckduckgo-html.xml
+++ b/src/app/webbrowser/searchengines/duckduckgo-html.xml
@@ -1,0 +1,5 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>DuckDuckGo (Html)</ShortName>
+  <Description>Search DuckDuckGo (Html)</Description>
+  <Url type="text/html" template="https://duckduckgo.com/html/?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/src/app/webbrowser/searchengines/duckduckgo-html.xml
+++ b/src/app/webbrowser/searchengines/duckduckgo-html.xml
@@ -1,5 +1,0 @@
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>DuckDuckGo (Html)</ShortName>
-  <Description>Search DuckDuckGo (Html)</Description>
-  <Url type="text/html" template="https://duckduckgo.com/html/?q={searchTerms}"/>
-</OpenSearchDescription>


### PR DESCRIPTION
the input-method-handler (cpp part) does reset the input method after each completed word.
as long as you stay within one text field or different text fields without closing the on screen keyboard, this workaround worked for me well on BQ Aquaris 4.5
the QML part (WebViewImpl.qml) is only needed for entering text fields without the on screen keyboard being open, or if the keyboard type does change
it unfortunately does require a timer, that resets the input method with a delay of 500ms.
altogether the goal here is to improve the input behavior described in https://github.com/ubports/morph-browser/issues/92 as much as possible, while the root cause has not been solved.