### PR TITLE
input-method-handler: only reset the input method, if last char in the commit string is a letter, space, or single quote

### DIFF
--- a/src/app/input-method-handler.cpp
+++ b/src/app/input-method-handler.cpp
@@ -26,7 +26,14 @@ bool inputMethodHandler::eventFilter(QObject* obj, QEvent* event)
     QInputMethodEvent * inputevent = static_cast<QInputMethodEvent*>(event);
 
     //qDebug() << "input event, predit string: " << inputevent->preeditString() << " commit string: " << inputevent->commitString();
-    // check the request contains informatino about the text format
+
+    // if the last char of the commit string is a number, do nothing (reset would change the keyboard layout back to letter mode)
+    if (! inputevent->commitString().isEmpty() && inputevent->commitString()[inputevent->commitString().length() - 1].isDigit())
+    {
+        return false;
+    }
+
+    // check the request contains information about the text format
     bool hasTextFormatInfo = false;
 
     for (auto attribute : inputevent->attributes())

--- a/src/app/input-method-handler.cpp
+++ b/src/app/input-method-handler.cpp
@@ -27,10 +27,15 @@ bool inputMethodHandler::eventFilter(QObject* obj, QEvent* event)
 
     //qDebug() << "input event, predit string: " << inputevent->preeditString() << " commit string: " << inputevent->commitString();
 
-    // if the last char of the commit string is a number, do nothing (reset would change the keyboard layout back to letter mode)
-    if (! inputevent->commitString().isEmpty() && inputevent->commitString()[inputevent->commitString().length() - 1].isDigit())
+    if (! inputevent->commitString().isEmpty() )
     {
-        return false;
+        QChar lastCharOfCommitString = inputevent->commitString()[inputevent->commitString().length() - 1];
+
+        // numbers and special chars do automatically commit, no reset done here as it would change the keyboard mode
+        if ( (lastCharOfCommitString != "'") && (lastCharOfCommitString != " ") && ! lastCharOfCommitString.isLetter() )
+        {
+            return false;
+        }
     }
 
     // check the request contains information about the text format


### PR DESCRIPTION
when entering a number at the end of a word, it is automatically commited. (no reset needed)