### PR TITLE
display error page if page load fails

### DIFF
--- a/src/Morph/Web/MorphWebView.qml
+++ b/src/Morph/Web/MorphWebView.qml
@@ -320,7 +320,7 @@ WebEngineView {
     readonly property bool lastLoadStopped: false // TODO internal.lastLoadRequestStatus === Oxide.LoadEvent.TypeStopped
     readonly property bool lastLoadFailed: internal.lastLoadRequestStatus === WebEngineLoadRequest.LoadFailedStatus
     onLoadingChanged: {
-        if (loadRequest.status != WebEngineLoadRequest.LoadStartedStatus) {
+        if ((loadRequest.url === url) && (loadRequest.status !== WebEngineLoadRequest.LoadStartedStatus)) {
             internal.lastLoadRequestStatus = loadRequest.status
         }
         internal.dismissCurrentContextualMenu()

--- a/src/Morph/Web/MorphWebView.qml
+++ b/src/Morph/Web/MorphWebView.qml
@@ -303,6 +303,7 @@ WebEngineView {
     QtObject {
         id: internal
         property int lastLoadRequestStatus: -1
+        property string lastLoadRequestErrorString: ""
         property QtObject contextModel: null
 
         function dismissCurrentContextualMenu() {
@@ -319,9 +320,11 @@ WebEngineView {
     readonly property bool lastLoadSucceeded: internal.lastLoadRequestStatus === WebEngineLoadRequest.LoadSucceededStatus
     readonly property bool lastLoadStopped: false // TODO internal.lastLoadRequestStatus === Oxide.LoadEvent.TypeStopped
     readonly property bool lastLoadFailed: internal.lastLoadRequestStatus === WebEngineLoadRequest.LoadFailedStatus
+    readonly property string lastLoadRequestErrorString: internal.lastLoadRequestErrorString
     onLoadingChanged: {
         if ((loadRequest.url === url) && (loadRequest.status !== WebEngineLoadRequest.LoadStartedStatus)) {
             internal.lastLoadRequestStatus = loadRequest.status
+            internal.lastLoadRequestErrorString = loadRequest.errorString
         }
         internal.dismissCurrentContextualMenu()
     }

--- a/src/app/ErrorSheet.qml
+++ b/src/app/ErrorSheet.qml
@@ -21,6 +21,7 @@ import Ubuntu.Components 1.3
 
 Rectangle {
     property string url
+    property string errorString
 
     signal refreshClicked()
 
@@ -41,6 +42,12 @@ Rectangle {
             // TRANSLATORS: %1 refers to the URL of the current page
             text: i18n.tr("It appears you are having trouble viewing: %1.").arg(url)
             wrapMode: Text.Wrap
+        }
+
+        Label {
+            width: parent.width
+            text: i18n.tr("Error: %1".arg(errorString))
+            visible: errorString !== ""
         }
 
         Label {

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -813,6 +813,12 @@ WebView {
         if (loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus) {
             zoomController.refresh()
         }
+
+        if (loadRequest.status === WebEngineLoadRequest.LoadFailedStatus) {
+           // ToDo: Is there a way to not load the "blink error message" in the first place ?
+           // we cannot change the url to "about:blank", because this would change the addressbar and remove the error state
+           webview.runJavaScript("document.removeChild(document.documentElement);")
+        }
     }
 
     // https://github.com/ubports/morph-browser/issues/92

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -810,6 +810,12 @@ WebView {
    }
 
    onLoadingChanged: {
+
+       // not about current url (e.g. finished loading of page we have already navigated away from)
+       if (loadRequest.url !== webview.url) {
+           return;
+       }
+
         if (loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus) {
             zoomController.refresh()
         }

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -691,8 +691,8 @@ WebView {
                     AbstractButton {
                         objectName: "touchSelectionAction_" + action.name
                         anchors {
-                            top: parent.top
-                            bottom: parent.bottom
+                            top: touchSelectionActionsRow.top
+                            bottom: touchSelectionActionsRow.bottom
                         }
                         width: Math.max(units.gu(4), implicitWidth) + units.gu(1)
                         action: modelData

--- a/src/app/webbrowser/AddressBar.qml
+++ b/src/app/webbrowser/AddressBar.qml
@@ -46,6 +46,7 @@ FocusScope {
     property color fgColor: Theme.palette.normal.baseText
 
     property var certificateErrorsMap: null
+    property bool lastLoadSucceeded
     readonly property bool hasSecurityError: (actualScheme === "https") && (certificateErrorsMap[UrlUtils.extractHost(actualUrl)] !== undefined)
     // is mixed content (https page loads http elements) blocked ? If not how to check it ?
     // show a warning for http / ftp pages ?
@@ -285,7 +286,7 @@ FocusScope {
 
         readonly property bool idle: !addressbar.loading && !addressbar.editing
         property var securityCertificateDetails: null
-        readonly property bool secureConnection: (actualScheme === "https") && ! hasSecurityError && ! hasSecurityWarning
+        readonly property bool secureConnection: lastLoadSucceeded && (actualScheme === "https") && ! hasSecurityError && ! hasSecurityWarning
         readonly property bool securityWarning: hasSecurityWarning
         readonly property bool securityError: hasSecurityError
 

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -329,7 +329,6 @@ BrowserView {
 
             anchors {
                 fill: tabContainer
-                topMargin: (chrome.state == "shown") ? chrome.height : 0
             }
             clip: true  // prevents component from overlapping bottom edge etc
 

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -297,7 +297,8 @@ BrowserView {
             }
             Component.onCompleted: setSource("../ErrorSheet.qml", {
                                                  "visible": Qt.binding(function(){ return currentWebview ? (! currentWebview.loading && currentWebview.lastLoadFailed) : false }),
-                                                 "url": Qt.binding(function(){ return currentWebview ? currentWebview.url : "" })
+                                                 "url": Qt.binding(function(){ return currentWebview ? currentWebview.url : "" }),
+                                                 "errorString" : Qt.binding(function() {return currentWebview ? currentWebview.lastLoadRequestErrorString : ""})
                                              })
             Connections {
                 target: errorSheetLoader.item

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -286,7 +286,7 @@ BrowserView {
                 fill: tabContainer
             }
             Component.onCompleted: setSource("../ErrorSheet.qml", {
-                                                 "visible": Qt.binding(function(){ return currentWebview ? currentWebview.lastLoadFailed : false }),
+                                                 "visible": Qt.binding(function(){ return currentWebview ? (! currentWebview.loading && currentWebview.lastLoadFailed) : false }),
                                                  "url": Qt.binding(function(){ return currentWebview ? currentWebview.url : "" })
                                              })
             Connections {

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -207,11 +207,21 @@ BrowserView {
         },
         Actions.Back {
             enabled: currentWebview ? currentWebview.canGoBack : false
-            onTriggered: currentWebview.goBack()
+            onTriggered: {
+                if (currentWebview.loading) {
+                    currentWebview.stop()
+                }
+                currentWebview.goBack()
+            }
         },
         Actions.Forward {
             enabled: currentWebview ? currentWebview.canGoForward : false
-            onTriggered: currentWebview.goForward()
+            onTriggered: {
+                if (currentWebview.loading) {
+                    currentWebview.stop()
+                }
+                currentWebview.goForward()
+            }
         },
         Actions.Reload {
             enabled: currentWebview

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -284,10 +284,9 @@ BrowserView {
             id: errorSheetLoader
             anchors {
                 fill: tabContainer
-                topMargin: (chrome.state == "shown") ? chrome.height : 0
             }
             Component.onCompleted: setSource("../ErrorSheet.qml", {
-                                                 "visible": Qt.binding(function(){ return currentWebview ? (currentWebview.LoadStatus === WebEngineView.LoadFailedStatus) : false }),
+                                                 "visible": Qt.binding(function(){ return currentWebview ? currentWebview.lastLoadFailed : false }),
                                                  "url": Qt.binding(function(){ return currentWebview ? currentWebview.url : "" })
                                              })
             Connections {

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -75,7 +75,18 @@ FocusScope {
             }
 
             enabled: findInPageMode || (internal.webview ? internal.webview.canGoBack : false)
-            onTriggered: findInPageMode ? (findInPageMode = false) : internal.webview.goBack()
+            onTriggered: {
+                if (findInPageMode) {
+                    findInPageMode = false
+                }
+                else {
+                    if (internal.webview.loading)
+                    {
+                        internal.webview.stop()
+                    }
+                    internal.webview.goBack()
+                    }
+                }
         }
 
         ChromeButton {
@@ -97,7 +108,13 @@ FocusScope {
 
             enabled: findInPageMode ? false :
                      (internal.webview ? internal.webview.canGoForward : false)
-            onTriggered: internal.webview.goForward()
+            onTriggered: {
+                if (internal.webview.loading)
+                {
+                    internal.webview.stop()
+                }
+                internal.webview.goForward()
+            }
         }
 
         AddressBar {

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -110,6 +110,7 @@ FocusScope {
             findInPageMode: findInPageMode
             findController: internal.webview ? internal.webview.findController : null
             certificateErrorsMap: internal.webview ? internal.webview.certificateErrorsMap : ({})
+            lastLoadSucceeded: internal.webview ? internal.webview.lastLoadSucceeded : false
 
             anchors {
                 left: parent.left

--- a/src/app/webcontainer/Chrome.qml
+++ b/src/app/webcontainer/Chrome.qml
@@ -67,7 +67,12 @@ ChromeBase {
             }
 
             enabled: chrome.webview ? chrome.webview.canGoBack : false
-            onTriggered: chrome.webview.goBack()
+            onTriggered: {
+                if (chrome.webview.loading) {
+                    chrome.webview.stop()
+                }
+                chrome.webview.goBack()
+            }
         }
 
         ChromeButton {
@@ -87,7 +92,12 @@ ChromeBase {
             }
 
             enabled: chrome.webview ? chrome.webview.canGoForward : false
-            onTriggered: chrome.webview.goForward()
+            onTriggered: {
+                if (chrome.webview.loading) {
+                    chrome.webview.stop()
+                }
+                chrome.webview.goForward()
+            }
         }
 
         Item {

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -206,7 +206,6 @@ BrowserView {
         Loader {
             anchors {
                 fill: containerWebView
-                topMargin: (!webapp.chromeless && chromeLoader.item.state == "shown") ? chromeLoader.item.height : 0
             }
             sourceComponent: ErrorSheet {
                 visible: containerWebView.currentWebview && containerWebView.currentWebview.lastLoadFailed

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -208,7 +208,7 @@ BrowserView {
                 fill: containerWebView
             }
             sourceComponent: ErrorSheet {
-                visible: containerWebView.currentWebview && containerWebView.currentWebview.lastLoadFailed
+                visible: containerWebView.currentWebview && ! containerWebView.currentWebview.loading && containerWebView.currentWebview.lastLoadFailed
                 url: containerWebView.currentWebview ? containerWebView.currentWebview.url : ""
                 onRefreshClicked: {
                     if (containerWebView.currentWebview)

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -220,9 +220,11 @@ BrowserView {
             sourceComponent: ErrorSheet {
                 visible: containerWebView.currentWebview && ! containerWebView.currentWebview.loading && containerWebView.currentWebview.lastLoadFailed
                 url: containerWebView.currentWebview ? containerWebView.currentWebview.url : ""
+                errorString: containerWebView.currentWebview ? containerWebView.currentWebview.lastLoadRequestErrorString : ""
                 onRefreshClicked: {
-                    if (containerWebView.currentWebview)
+                    if (containerWebView.currentWebview) {
                         containerWebView.currentWebview.reload()
+                    }
                 }
             }
             asynchronous: true

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -72,13 +72,23 @@ BrowserView {
             enabled: webapp.backForwardButtonsVisible &&
                      containerWebView.currentWebview &&
                      containerWebView.currentWebview.canGoBack
-            onTriggered: containerWebView.currentWebview.goBack()
+            onTriggered: {
+                if (containerWebView.currentWebview.loading) {
+                    containerWebView.currentWebview.stop()
+                }
+                containerWebView.currentWebview.goBack()
+            }
         },
         Actions.Forward {
             enabled: webapp.backForwardButtonsVisible &&
                      containerWebView.currentWebview &&
                      containerWebView.currentWebview.canGoForward
-            onTriggered: containerWebView.currentWebview.goForward()
+            onTriggered: {
+                if (containerWebView.currentWebview.loading) {
+                    containerWebView.currentWebview.stop()
+                }
+                containerWebView.currentWebview.goForward()
+            }
         },
         Actions.Reload {
             onTriggered: containerWebView.currentWebview.reload()

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -96,7 +96,7 @@ FocusScope {
 
         onLastLoadSucceededChanged: {
           if (! initialUrlLoaded && webappContainerWebViewLoader.item.lastLoadSucceeded) {
-             webappContainerWebViewLoader.item.url = containerWebView.url
+             webappContainerWebViewLoader.item.runJavaScript("window.location.replace('%1')".arg(containerWebView.url))
              initialUrlLoaded = true
           }
         }

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -107,33 +107,44 @@ FocusScope {
     onUrlChanged: if (webappContainerWebViewLoader.item) webappContainerWebViewLoader.item.url = url
 
     Component.onCompleted: {
-        var webappEngineSource = Qt.resolvedUrl("WebViewImplOxide.qml");
+        setSourceTimer.restart()
+    }
 
-        // This is an experimental, UNSUPPORTED, API
-        // It loads an alternative webview, adjusted for a specific webapp
-        if (webviewOverrideFile.toString()) {
-            console.log("Loading custom webview from " + webviewOverrideFile);
-            webappEngineSource = webviewOverrideFile;
+    Timer
+    {
+        id: setSourceTimer
+        interval: 40
+        repeat: false
+        onTriggered: {
+
+                var webappEngineSource = Qt.resolvedUrl("WebViewImplOxide.qml");
+
+                // This is an experimental, UNSUPPORTED, API
+                // It loads an alternative webview, adjusted for a specific webapp
+                if (webviewOverrideFile.toString()) {
+                    console.log("Loading custom webview from " + webviewOverrideFile);
+                    webappEngineSource = webviewOverrideFile;
+                }
+
+                webappContainerWebViewLoader.setSource(
+                                 webappEngineSource,
+                                 { window: containerWebView.window
+                                 , localUserAgentOverride: containerWebview.localUserAgentOverride
+                                 , url: containerWebview.url
+                                 , webappName: containerWebview.webappName
+                                 , dataPath: dataPath
+                                 , webappUrlPatterns: containerWebview.webappUrlPatterns
+                                 , developerExtrasEnabled: containerWebview.developerExtrasEnabled
+                                 , popupRedirectionUrlPrefixPattern: containerWebview.popupRedirectionUrlPrefixPattern
+                                 , blockOpenExternalUrls: containerWebview.blockOpenExternalUrls
+                                 , runningLocalApplication: containerWebview.runningLocalApplication
+                                 , popupController: popupController
+                                 , overlayViewsParent: containerWebview.parent
+                                 , wide: containerWebview.wide
+                                 , mediaAccessDialogComponent: mediaAccessDialogComponent
+                                 , openExternalUrlInOverlay: containerWebview.openExternalUrlInOverlay
+                                 , popupBlockerEnabled: containerWebview.popupBlockerEnabled})
         }
-
-        webappContainerWebViewLoader.setSource(
-                    webappEngineSource,
-                    { window: containerWebView.window
-                    , localUserAgentOverride: containerWebview.localUserAgentOverride
-                    , url: containerWebview.url
-                    , webappName: containerWebview.webappName
-                    , dataPath: dataPath
-                    , webappUrlPatterns: containerWebview.webappUrlPatterns
-                    , developerExtrasEnabled: containerWebview.developerExtrasEnabled
-                    , popupRedirectionUrlPrefixPattern: containerWebview.popupRedirectionUrlPrefixPattern
-                    , blockOpenExternalUrls: containerWebview.blockOpenExternalUrls
-                    , runningLocalApplication: containerWebview.runningLocalApplication
-                    , popupController: popupController
-                    , overlayViewsParent: containerWebview.parent
-                    , wide: containerWebview.wide
-                    , mediaAccessDialogComponent: mediaAccessDialogComponent
-                    , openExternalUrlInOverlay: containerWebview.openExternalUrlInOverlay
-                    , popupBlockerEnabled: containerWebview.popupBlockerEnabled})
     }
 }
 

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -98,7 +98,7 @@ FocusScope {
         onLastLoadSucceededChanged: {
           if (! initialUrlLoaded && webappContainerWebViewLoader.item.lastLoadSucceeded) {
              if (UrlUtils.extractScheme(containerWebView.url) !== 'file') {
-               webappContainerWebViewLoader.item.runJavaScript("window.location = '%1'".arg(containerWebView.url))
+               webappContainerWebViewLoader.item.runJavaScript("window.location.replace('%1')".arg(containerWebView.url))
              }
              initialUrlLoaded = true
           }

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -22,6 +22,7 @@ import Ubuntu.Components 1.3
 import Ubuntu.Unity.Action 1.1 as UnityActions
 import Ubuntu.UnityWebApps 0.1 as UnityWebApps
 import "../actions" as Actions
+import "../UrlUtils.js" as UrlUtils
 import ".."
 
 FocusScope {
@@ -96,7 +97,9 @@ FocusScope {
 
         onLastLoadSucceededChanged: {
           if (! initialUrlLoaded && webappContainerWebViewLoader.item.lastLoadSucceeded) {
-             webappContainerWebViewLoader.item.runJavaScript("window.location.replace('%1')".arg(containerWebView.url))
+             if (UrlUtils.extractScheme(containerWebView.url) !== 'file') {
+               webappContainerWebViewLoader.item.runJavaScript("window.location = '%1'".arg(containerWebView.url))
+             }
              initialUrlLoaded = true
           }
         }
@@ -125,7 +128,7 @@ FocusScope {
                     webappEngineSource,
                     { window: containerWebView.window
                     , localUserAgentOverride: containerWebview.localUserAgentOverride
-                    , url: "about:blank"
+                    , url: (UrlUtils.extractScheme(containerWebview.url) === 'file') ? containerWebview.url : 'about:blank'
                     , webappName: containerWebview.webappName
                     , dataPath: dataPath
                     , webappUrlPatterns: containerWebview.webappUrlPatterns

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -107,44 +107,33 @@ FocusScope {
     onUrlChanged: if (webappContainerWebViewLoader.item) webappContainerWebViewLoader.item.url = url
 
     Component.onCompleted: {
-        setSourceTimer.restart()
-    }
+        var webappEngineSource = Qt.resolvedUrl("WebViewImplOxide.qml");
 
-    Timer
-    {
-        id: setSourceTimer
-        interval: 40
-        repeat: false
-        onTriggered: {
-
-                var webappEngineSource = Qt.resolvedUrl("WebViewImplOxide.qml");
-
-                // This is an experimental, UNSUPPORTED, API
-                // It loads an alternative webview, adjusted for a specific webapp
-                if (webviewOverrideFile.toString()) {
-                    console.log("Loading custom webview from " + webviewOverrideFile);
-                    webappEngineSource = webviewOverrideFile;
-                }
-
-                webappContainerWebViewLoader.setSource(
-                                 webappEngineSource,
-                                 { window: containerWebView.window
-                                 , localUserAgentOverride: containerWebview.localUserAgentOverride
-                                 , url: containerWebview.url
-                                 , webappName: containerWebview.webappName
-                                 , dataPath: dataPath
-                                 , webappUrlPatterns: containerWebview.webappUrlPatterns
-                                 , developerExtrasEnabled: containerWebview.developerExtrasEnabled
-                                 , popupRedirectionUrlPrefixPattern: containerWebview.popupRedirectionUrlPrefixPattern
-                                 , blockOpenExternalUrls: containerWebview.blockOpenExternalUrls
-                                 , runningLocalApplication: containerWebview.runningLocalApplication
-                                 , popupController: popupController
-                                 , overlayViewsParent: containerWebview.parent
-                                 , wide: containerWebview.wide
-                                 , mediaAccessDialogComponent: mediaAccessDialogComponent
-                                 , openExternalUrlInOverlay: containerWebview.openExternalUrlInOverlay
-                                 , popupBlockerEnabled: containerWebview.popupBlockerEnabled})
+        // This is an experimental, UNSUPPORTED, API
+        // It loads an alternative webview, adjusted for a specific webapp
+        if (webviewOverrideFile.toString()) {
+            console.log("Loading custom webview from " + webviewOverrideFile);
+            webappEngineSource = webviewOverrideFile;
         }
+
+        webappContainerWebViewLoader.setSource(
+                    webappEngineSource,
+                    { window: containerWebView.window
+                    , localUserAgentOverride: containerWebview.localUserAgentOverride
+                    , url: containerWebview.url
+                    , webappName: containerWebview.webappName
+                    , dataPath: dataPath
+                    , webappUrlPatterns: containerWebview.webappUrlPatterns
+                    , developerExtrasEnabled: containerWebview.developerExtrasEnabled
+                    , popupRedirectionUrlPrefixPattern: containerWebview.popupRedirectionUrlPrefixPattern
+                    , blockOpenExternalUrls: containerWebview.blockOpenExternalUrls
+                    , runningLocalApplication: containerWebview.runningLocalApplication
+                    , popupController: popupController
+                    , overlayViewsParent: containerWebview.parent
+                    , wide: containerWebview.wide
+                    , mediaAccessDialogComponent: mediaAccessDialogComponent
+                    , openExternalUrlInOverlay: containerWebview.openExternalUrlInOverlay
+                    , popupBlockerEnabled: containerWebview.popupBlockerEnabled})
     }
 }
 

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -29,6 +29,7 @@ FocusScope {
 
     property Window window
 
+    property bool initialUrlLoaded: false
     property string url: ""
     property bool developerExtrasEnabled: false
     property string webappName: ""
@@ -88,12 +89,16 @@ FocusScope {
         onSamlRequestUrlPatternReceived: {
             samlRequestUrlPatternReceived(urlPattern)
         }
-    }
 
-    Connections {
-        target: webappContainerWebViewLoader.item
         onThemeColorMetaInformationDetected: {
             themeColorMetaInformationDetected(theme_color)
+        }
+
+        onLastLoadSucceededChanged: {
+          if (! initialUrlLoaded && webappContainerWebViewLoader.item.lastLoadSucceeded) {
+             webappContainerWebViewLoader.item.url = containerWebView.url
+             initialUrlLoaded = true
+          }
         }
     }
 
@@ -120,7 +125,7 @@ FocusScope {
                     webappEngineSource,
                     { window: containerWebView.window
                     , localUserAgentOverride: containerWebview.localUserAgentOverride
-                    , url: containerWebview.url
+                    , url: "about:blank"
                     , webappName: containerWebview.webappName
                     , dataPath: dataPath
                     , webappUrlPatterns: containerWebview.webappUrlPatterns


### PR DESCRIPTION
ErrorSheet: in Browser.qml use the property lastLoadFailed for the binding (was already correct in WebApp.qml)

Browser.qml / WebApp.qml: remove the top margin of the error sheet
AddressBar: new lastLoadSucceeded property: show lock symbol only, if last load was successful for https pages

fixes https://github.com/ubports/morph-browser/issues/118

now the chances are high that it fixes https://github.com/ubports/morph-browser/issues/133 as well