### PR TITLE
close current tab / close single window

### DIFF
--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -423,6 +423,14 @@ WebView {
         zoomMenu.visible = true
     }
 
+    function hideZoomMenu() {
+        zoomMenu.visible = false
+    }
+
+    function hideContextMenu() {
+        quickMenu.visible = false
+    }
+
     UbuntuShape {
             z:3
             id: quickMenu

--- a/src/app/webbrowser/AddressBar.qml
+++ b/src/app/webbrowser/AddressBar.qml
@@ -42,6 +42,7 @@ FocusScope {
     property bool editing: false
     property bool showFavicon: true
     property bool findInPageMode: false
+    property bool tabListMode: false
     property var findController: null
     property color fgColor: Theme.palette.normal.baseText
 

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -441,7 +441,13 @@ BrowserView {
 
         anchors.fill: parent
         visible: bottomEdgeHandle.dragging || tabslist.animating || (state == "shown")
-        onVisibleChanged: chrome.hidden = visible
+        onVisibleChanged: {
+            if (visible)
+            {
+                currentWebview.hideZoomMenu()
+                currentWebview.hideContextMenu()
+            }
+        }
 
         states: State {
             name: "shown"
@@ -564,6 +570,7 @@ BrowserView {
         touchEnabled: internal.hasTouchScreen
 
         tabsBarDimmed: dropAreaTopCover.containsDrag || dropAreaBottomCover.containsDrag
+        tabListMode: recentView.visible
 
         property bool hidden: false
 
@@ -578,6 +585,7 @@ BrowserView {
             return tab ? BookmarksModel.contains(tab.url) : false
         }
         bookmarked: isCurrentUrlBookmarked()
+        onCloseTabRequested: internal.closeCurrentTab()
         onToggleBookmark: {
             if (isCurrentUrlBookmarked()) BookmarksModel.remove(tab.url)
             else internal.addBookmark(tab.url, tab.title, tab.icon)

--- a/src/app/webbrowser/Chrome.qml
+++ b/src/app/webbrowser/Chrome.qml
@@ -30,12 +30,14 @@ ChromeBase {
     property alias searchUrl: navigationBar.searchUrl
     property alias text: navigationBar.text
     property alias bookmarked: navigationBar.bookmarked
+    signal closeTabRequested()
     signal toggleBookmark()
     property alias drawerActions: navigationBar.drawerActions
     property alias drawerOpen: navigationBar.drawerOpen
     property alias requestedUrl: navigationBar.requestedUrl
     property alias canSimplifyText: navigationBar.canSimplifyText
     property alias findInPageMode: navigationBar.findInPageMode
+    property alias tabListMode: navigationBar.tabListMode
     property alias editing: navigationBar.editing
     property alias incognito: navigationBar.incognito
     property alias showTabsBar: tabsBar.active
@@ -119,6 +121,7 @@ ChromeBase {
             }
             height: units.gu(6)
 
+            onCloseTabRequested: chrome.closeTabRequested()
             onToggleBookmark: chrome.toggleBookmark()
         }
     }

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -29,12 +29,14 @@ FocusScope {
     property alias searchUrl: addressbar.searchUrl
     readonly property string text: addressbar.text
     property alias bookmarked: addressbar.bookmarked
+    signal closeTabRequested()
     signal toggleBookmark()
     property list<Action> drawerActions
     readonly property bool drawerOpen: internal.openDrawer
     property alias requestedUrl: addressbar.requestedUrl
     property alias canSimplifyText: addressbar.canSimplifyText
     property alias findInPageMode: addressbar.findInPageMode
+    property alias tabListMode: addressbar.tabListMode
     property alias editing: addressbar.editing
     property alias incognito: addressbar.incognito
     property alias showFaviconInAddressBar: addressbar.showFavicon
@@ -184,6 +186,24 @@ FocusScope {
                 visible: findInPageMode
                 enabled: internal.webview && internal.webview.findController && internal.webview.findController.foundMatch
                 onTriggered: internal.webview.findController.next()
+            }
+
+            ChromeButton {
+                id: closeButton
+                objectName: "closeButton"
+
+                iconName: "close"
+                iconSize: 0.3 * height
+                iconColor: root.iconColor
+
+                height: root.height
+                width: height * 0.8
+
+                anchors.verticalCenter: parent.verticalCenter
+
+                visible: tabListMode
+
+                onTriggered: closeTabRequested()
             }
 
             ChromeButton {

--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -136,6 +136,15 @@ QtObject {
                     }
                 }
 
+                if (allWindows.length > 1)
+                {
+                    for (var win in allWindows) {
+                        if (this === allWindows[win]) {
+                            allWindows.splice(win, 1)
+                            return
+                        }
+                    }
+                }
                 destroy()
             }
 
@@ -169,14 +178,6 @@ QtObject {
             }
 
             Component.onCompleted: allWindows.push(this)
-            Component.onDestruction: {
-                for (var w in allWindows) {
-                    if (this === allWindows[w]) {
-                        allWindows.splice(w, 1)
-                        return
-                    }
-                }
-            }
 
             Browser {
                 id: browser


### PR DESCRIPTION
- morph-browser.qml: delete the closed window from the list before destruction
(closing one window does no longer close the others)
fixes https://github.com/ubports/morph-browser/issues/35
probably fixes https://github.com/ubports/morph-browser/issues/130
- WebViewImpl.qml: add hideZoomMenu() and hideContextMenu()
- NavigationBar.qml: add close button that is only visible in "tabList" mode
- other QML files get the tabListMode property and closeTabRequested() signal
(it is now possible to close the current tab)
fixes https://github.com/ubports/morph-browser/issues/50