### PR TITLE
"keep display on" for audio playback and fullscreen (video)

### DIFF
--- a/src/app/BrowserWindow.qml
+++ b/src/app/BrowserWindow.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.4
 import QtQuick.Window 2.2
+import QtSystemInfo 5.0
 import Ubuntu.Components 1.3
 
 Window {
@@ -39,6 +40,11 @@ Window {
     QtObject {
         id: internal
         property int currentWindowState: Window.Windowed
+    }
+
+    ScreenSaver {
+        id: screenSaver
+        screenSaverEnabled: ! ( window.active && (window.currentWebview.isFullScreen || window.currentWebview.recentlyAudible) )
     }
 
     Connections {


### PR DESCRIPTION
turn off screensaver while the browser window is active and "recentlyAudible" or "isFullScreen" property of the current webview is true

fixes https://github.com/ubports/morph-browser/issues/71