### PR TITLE
use a Rectangle for BottomEdgeHint (instead of Image)

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -860,35 +860,31 @@ BrowserView {
         }
     }
 
-    Image {
+    Rectangle {
         id: bottomEdgeHint
-        source: "assets/bottom_edge_hint.png"
+        color: theme.palette.normal.background
+        border.color: (color.hslLightness > 0.5) ? Qt.darker(color, 1.05) : Qt.lighter(color, 1.05)
+        radius: units.gu(1.5)
+        height: units.gu(4)
+        width: units.gu(10)
         property bool forceShow: false
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
-            bottomMargin: (((chrome.state == "shown") && browser.currentWebview && !browser.currentWebview.fullscreen) || forceShow) ? 0 : -height
+            bottomMargin: (((chrome.state == "shown") && browser.currentWebview && !browser.currentWebview.fullscreen) || forceShow) ? -height / 2 : -height
             Behavior on bottomMargin {
                 UbuntuNumberAnimation {}
             }
         }
         visible: bottomEdgeHandle.enabled && !internal.hasMouse
         opacity: recentView.visible ? 0 : 1
-        asynchronous: true
         Behavior on opacity {
             UbuntuNumberAnimation {}
         }
-
-        ColorOverlay {
-            anchors.fill: bottomEdgeHint
-            source: bottomEdgeHint
-            color: theme.palette.normal.background
-        }
-
         Label {
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                verticalCenter: parent.verticalCenter
+                verticalCenter: parent.verticalCenter - parent.height / 4
                 verticalCenterOffset: units.dp(2)
             }
 


### PR DESCRIPTION
the color overlay of the png image has produced artifacts for me:
![screenshot20181230_201550334](https://user-images.githubusercontent.com/848115/50550419-a07e1a00-0c70-11e9-825d-eb58b720aa9c.png)
So to use this we have to use a svg instead and make sure the transparency color is set correctly. (or correct the png to be completely transparent in the outside region)
But I thought, why not just omit the image completely and use a rectangle instead?
It has not such a smooth shadow than before (more simplistic), but is more suitable for themes I think.