### PR TITLE
- fix empty favicons in the HistoryModel

### DIFF
--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -832,7 +832,7 @@ WebView {
         if (loadRequest.status === WebEngineLoadRequest.LoadFailedStatus) {
            // ToDo: Is there a way to not load the "blink error message" in the first place ?
            // we cannot change the url to "about:blank", because this would change the addressbar and remove the error state
-           webview.runJavaScript("document.removeChild(document.documentElement);")
+           webview.runJavaScript("if (document.documentElement) {document.removeChild(document.documentElement);}")
         }
     }
 

--- a/src/app/webbrowser/TabComponent.qml
+++ b/src/app/webbrowser/TabComponent.qml
@@ -372,7 +372,7 @@ Component {
                     return
                 }
 
-                if (webviewInternal.storedUrl.toString()) {
+                if ((icon.toString() !== '') && webviewInternal.storedUrl.toString()) {
                     HistoryModel.update(webviewInternal.storedUrl, webviewInternal.title, (UrlUtils.schemeIs(icon, "image") && UrlUtils.hostIs(icon, "favicon")) ? icon.toString().substring(("image://favicon/").length) : icon)
                 }
             }


### PR DESCRIPTION
- error page only is cleared if document element exists