### PR TITLE
use currentWebview for PopupUtils

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -692,7 +692,7 @@ BrowserView {
                 iconName: "save-as"
                 enabled: currentWebview
                 onTriggered: {
-                    var savePageDialog = PopupUtils.open(Qt.resolvedUrl("../SavePageDialog.qml"), this);
+                    var savePageDialog = PopupUtils.open(Qt.resolvedUrl("../SavePageDialog.qml"), currentWebview);
                     savePageDialog.saveAsHtml.connect( function() { currentWebview.triggerWebAction(WebEngineView.SavePage) } )
                     // the filename of the PDF is determined from the title (replace not allowed / problematic chars with '_')
                     // the QtWebEngine does give the filename (.mhtml) for the SavePage action with that pattern as well


### PR DESCRIPTION
maldito found that that the recent change broke the export functionality.
(the additional parameter has been added to make it work on private windows. instead of 'this'  use currentWebview.