### PR TITLE
before saving the session before the last window is closed, call setFullscreen(false)

### DIFF
--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -114,6 +114,7 @@ QtObject {
 
             onClosing: {
                 if (allWindows.length == 1) {
+                    allWindows[0].setFullscreen(false)
                     if (tabsModel.count > 0) {
                         session.save()
                     } else {


### PR DESCRIPTION
fixes https://github.com/ubports/morph-browser/issues/202