### PR TITLE
create a sharedIncognitoContext (offTheRecord = true) that is used for incognito webviews

### DIFF
--- a/src/Morph/Web/MorphSharedWebContext.qml
+++ b/src/Morph/Web/MorphSharedWebContext.qml
@@ -26,4 +26,9 @@ QtObject {
     property QtObject sharedContext: MorphWebContext {
         id: context
     }
+
+    property QtObject sharedIncognitoContext: MorphWebContext {
+        id: incognitoContext
+        offTheRecord: true
+    }
 }

--- a/src/Morph/Web/MorphWebView.qml
+++ b/src/Morph/Web/MorphWebView.qml
@@ -29,12 +29,6 @@ WebEngineView {
     property alias context: _webview.profile
     property var incognito: false
 
-    Binding {
-      target: _webview.context
-      property: "offTheRecord"
-      value: _webview.incognito
-    }
-
     property var locationBarController: QtObject {
         readonly property int modeAuto: 0
         readonly property int modeShown: 1
@@ -62,7 +56,7 @@ WebEngineView {
      */
     function navigationRequestedDelegate(request) { }
 
-    context: SharedWebContext.sharedContext
+    context: incognito ? SharedWebContext.sharedIncognitoContext : SharedWebContext.sharedContext
 
     /*
     messageHandlers: [


### PR DESCRIPTION
(all non-incognito webviews use the profile "SharedWebContext.sharedContext", the incognito webviews use the profile "SharedWebContext.sharedIncognitoContext")

fixes https://github.com/ubports/morph-browser/issues/237

I have tried the following on Firefox:
Open Github -> account is already logged in
open a private window, navigate to github
- no user is logged in
open another private window, navigate to github:
- no user is logged in

- Log in to github in one of the private windows
- Refresh the other private window
-> In both windows the user is logged on to github

So they seem to share the same "private profile" across the windows, so that would then be the same behavior for morph with this change.

Previously there was only one (Singleton) profile, and its "offTheRecord" flag was changed according to the incognito state of the webview. But then always the new webview "wins" and changes the "offTheRecord" for the others as well. Now there are 2 separate profiles.