### PR TITLE
Remove the DDG search with canonical string

### DIFF
--- a/src/app/webbrowser/searchengines/duckduckgo.xml
+++ b/src/app/webbrowser/searchengines/duckduckgo.xml
@@ -1,6 +1,0 @@
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>DuckDuckGo</ShortName>
-  <Description>Search DuckDuckGo</Description>
-  <Url type="text/html" template="https://duckduckgo.com/?q={searchTerms}&amp;t=canonical"/>
-  <Url type="application/x-suggestions+json" template="https://ac.duckduckgo.com/ac/?q={searchTerms}&amp;type=list"/>
-</OpenSearchDescription>

--- a/src/app/webbrowser/searchengines/duckduckgo.xml
+++ b/src/app/webbrowser/searchengines/duckduckgo.xml
@@ -1,5 +1,5 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>DuckDuckGo (HTML-only)</ShortName>
-  <Description>Search DuckDuckGo (HTML-only)</Description>
+  <ShortName>DuckDuckGo</ShortName>
+  <Description>Search DuckDuckGo</Description>
   <Url type="text/html" template="https://duckduckgo.com/html/?q={searchTerms}"/>
 </OpenSearchDescription>


### PR DESCRIPTION
Removed the DuckDuckGo search engine that adds the "t=canonical" string to the searches. this could lead to misunderstanding or (wrong) inference like this https://forums.ubports.com/topic/3309/morph-browser-explanation-about-canonical-in-url
also ubports is indipendent from canonical so this could lead to wrong statistic analisys about ubuntu diffusion (with accusations of inflating data) and biases about ubports project and its indipendence. use instead the duckduckgo-html-only.xml (renamed duckduckgo.xml)