### PR TITLE
remove only the t=canonical string

### DIFF
--- a/src/app/webbrowser/searchengines/duckduckgo.xml
+++ b/src/app/webbrowser/searchengines/duckduckgo.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <ShortName>DuckDuckGo</ShortName>
   <Description>Search DuckDuckGo</Description>
-  <Url type="text/html" template="https://duckduckgo.com/?q={searchTerms}&amp;t=canonical"/>
+  <Url type="text/html" template="https://duckduckgo.com/?q={searchTerms}"/>
   <Url type="application/x-suggestions+json" template="https://ac.duckduckgo.com/ac/?q={searchTerms}&amp;type=list"/>
 </OpenSearchDescription>


### PR DESCRIPTION
Revert commit 04f61fcc88d06137525c7866fc0e5029dffab266 that added the t=canonical string to the searches.
substitute the "Remove the DDG search with canonical string #250"