### PR TITLE
Xenial   defaultzoom

### DIFF
--- a/src/app/webbrowser/SettingsPage.qml
+++ b/src/app/webbrowser/SettingsPage.qml
@@ -17,6 +17,7 @@
  */
 
 import QtQuick 2.4
+import QtQuick.Controls 2.2
 import Qt.labs.settings 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
@@ -154,21 +155,18 @@ FocusScope {
 
                     ListItemLayout {
                         title.text: i18n.tr("Default Zoom")
-                        subtitle.text: Math.round(defaultZoomFactorSlider.value * 100) + "%"
-
-                        Slider {
-                            width: settingsCol.width * 0.45
-                            id: defaultZoomFactorSlider
-                            minimumValue: 0.25
-                            maximumValue: 5.0
-                            function formatValue(v) { return Math.round(v * 100 / 5) * 5 + "%" }
-                            value: settingsObject.zoomFactor
-                            onValueChanged: {
-                                // round for 5% steps (e.g. 95%, 100%)
-                                var percentValue = Math.round(value * 100 / 5) * 5
-                                settingsObject.zoomFactor = percentValue / 100
-                            }
-                            SlotsLayout.position: SlotsLayout.Trailing
+                        SpinBox {
+                          id: defaultZoomFactorSelector
+                          value: Math.round(settingsObject.zoomFactor * 100 * 5) / 5
+                          from: 25
+                          to: 500
+                          stepSize: 5
+                          textFromValue: function(value, locale) {
+                            return value + "%"
+                          }
+                          onValueModified: {
+                            settingsObject.zoomFactor = value / 100
+                          }
                         }
                         Icon {
                             id: resetZoom
@@ -190,11 +188,6 @@ FocusScope {
                         }
                    }
 
-                    Binding {
-                        target: defaultZoomFactorSlider
-                        property: "value"
-                        value: settingsObject.zoomFactor
-                    }
                 }
 
                 ListItem {

--- a/src/app/webbrowser/SettingsPage.qml
+++ b/src/app/webbrowser/SettingsPage.qml
@@ -165,7 +165,7 @@ FocusScope {
                             return value + "%"
                           }
                           onValueModified: {
-                            settingsObject.zoomFactor = value / 100
+                            settingsObject.zoomFactor = (Math.round(value / 5) * 5) / 100
                           }
                         }
                         Icon {

--- a/src/app/webbrowser/SettingsPage.qml
+++ b/src/app/webbrowser/SettingsPage.qml
@@ -157,7 +157,7 @@ FocusScope {
                         title.text: i18n.tr("Default Zoom")
                         SpinBox {
                           id: defaultZoomFactorSelector
-                          value: Math.round(settingsObject.zoomFactor * 100 * 5) / 5
+                          value: Math.round(settingsObject.zoomFactor * 100 * stepSize) / stepSize
                           from: 25
                           to: 500
                           stepSize: 5
@@ -165,7 +165,7 @@ FocusScope {
                             return value + "%"
                           }
                           onValueModified: {
-                            settingsObject.zoomFactor = (Math.round(value / 5) * 5) / 100
+                            settingsObject.zoomFactor = (Math.round(value / stepSize) * stepSize) / 100
                           }
                         }
                         Icon {

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -370,12 +370,6 @@ Common.BrowserView {
                           })
             }
 
-            onStatusChanged: {
-                if (status != Loader.Ready) {
-                    webapp.currentWebview.zoomController.reset()
-                }
-            }
-
             Connections {
                 target: webappSettingsViewLoader.item
                 onClearCache: {

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -370,6 +370,12 @@ Common.BrowserView {
                           })
             }
 
+            onStatusChanged: {
+                if (status != Loader.Ready) {
+                    webapp.currentWebview.zoomController.reset()
+                }
+            }
+
             Connections {
                 target: webappSettingsViewLoader.item
                 onClearCache: {

--- a/src/app/webcontainer/WebappSettingsPage.qml
+++ b/src/app/webcontainer/WebappSettingsPage.qml
@@ -58,7 +58,7 @@ FocusScope {
                         title.text: i18n.tr("Default Zoom")
                         SpinBox {
                           id: defaultZoomFactorSelector
-                          value: Math.round(settingsObject.zoomFactor * 100 * 5) / 5
+                          value: Math.round(settingsObject.zoomFactor * 100 * stepSize) / stepSize
                           from: 25
                           to: 500
                           stepSize: 5
@@ -66,7 +66,7 @@ FocusScope {
                             return value + "%"
                           }
                           onValueModified: {
-                            settingsObject.zoomFactor = (Math.round(value / 5) * 5) / 100
+                            settingsObject.zoomFactor = (Math.round(value / stepSize) * stepSize) / 100
                           }
                         }
                         Icon {

--- a/src/app/webcontainer/WebappSettingsPage.qml
+++ b/src/app/webcontainer/WebappSettingsPage.qml
@@ -17,6 +17,7 @@
  */
 
 import QtQuick 2.4
+import QtQuick.Controls 2.2
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import QtWebEngine 1.5
@@ -55,21 +56,18 @@ FocusScope {
 
                     ListItemLayout {
                         title.text: i18n.tr("Default Zoom")
-                        subtitle.text: Math.round(defaultZoomFactorSlider.value * 100) + "%"
-
-                        Slider {
-                            width: settingsCol.width * 0.45
-                            id: defaultZoomFactorSlider
-                            minimumValue: 0.25
-                            maximumValue: 5.0
-                            function formatValue(v) { return Math.round(v * 100 / 5) * 5 + "%" }
-                            value: settingsObject.zoomFactor
-                            onValueChanged: {
-                                // round for 5% steps (e.g. 95%, 100%)
-                                var percentValue = Math.round(value * 100 / 5) * 5
-                                settingsObject.zoomFactor = percentValue / 100
-                            }
-                            SlotsLayout.position: SlotsLayout.Trailing
+                        SpinBox {
+                          id: defaultZoomFactorSelector
+                          value: Math.round(settingsObject.zoomFactor * 100 * 5) / 5
+                          from: 25
+                          to: 500
+                          stepSize: 5
+                          textFromValue: function(value, locale) {
+                            return value + "%"
+                          }
+                          onValueModified: {
+                            settingsObject.zoomFactor = value / 100
+                          }
                         }
                         Icon {
                             id: resetZoom
@@ -89,12 +87,6 @@ FocusScope {
                                 topMargin: units.gu(2)
                             }
                         }
-                    }
-
-                    Binding {
-                        target: defaultZoomFactorSlider
-                        property: "value"
-                        value: settingsObject.zoomFactor
                     }
                 }
 

--- a/src/app/webcontainer/WebappSettingsPage.qml
+++ b/src/app/webcontainer/WebappSettingsPage.qml
@@ -66,7 +66,7 @@ FocusScope {
                             return value + "%"
                           }
                           onValueModified: {
-                            settingsObject.zoomFactor = value / 100
+                            settingsObject.zoomFactor = (Math.round(value / 5) * 5) / 100
                           }
                         }
                         Icon {


### PR DESCRIPTION
use SpinBox from QtQuick controls instead of the Slider for default zoom
fixes https://github.com/ubports/morph-browser/issues/233