### PR TITLE
Relax the BrowserWindow minimumWidth

### DIFF
--- a/src/app/BrowserWindow.qml
+++ b/src/app/BrowserWindow.qml
@@ -31,7 +31,7 @@ Window {
 
     contentOrientation: Screen.orientation
 
-    minimumWidth: units.gu(50)
+    minimumWidth: units.gu(40)
     minimumHeight: units.gu(20)
 
     width: units.gu(100)


### PR DESCRIPTION
Relax the BrowserWindow minimumWidth as some devices have a width
smaller than the minimum causing the app to overflow.