### PR TITLE
Add dim background color to select element popup

### DIFF
--- a/src/Morph/Web/MorphSelectOverrideDialog.qml
+++ b/src/Morph/Web/MorphSelectOverrideDialog.qml
@@ -27,7 +27,7 @@ Popups.Dialog {
     objectName: "selectOverrideDialog"
     modal: true
 
-    __dimBackground: false //avoid default opaque background
+    //__dimBackground: false //avoid default opaque background
     grabDismissAreaEvents: false //allow this component to handle the click on the background
 
     property string options: ""


### PR DESCRIPTION
First, thanks to @lduboeuf for this implementation! This is a great looking way to handle these menus, much easier to interact with than the tiny box that shows up in Demo Browser.

However I am curious why the dimming of the background was disabled? On a white page it makes the select dialogue look very undefined... I think at a minimum there should be a border to define the popup, or just letting the site be dimmed which I personally like.

My suggestion:
![screenshot20200214_071231219](https://user-images.githubusercontent.com/7121141/74545297-7bdd1400-4efd-11ea-9cbc-c1546a1445d8.png)

As exists now:
![screenshot20200214_074419061](https://user-images.githubusercontent.com/7121141/74545530-dbd3ba80-4efd-11ea-9a49-e5b294fbc4cb.png)

I know there is a slight border, but it doesn't feel like enough. Just a suggestion.