### PR TITLE
Auto hide the bottom edge hint

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -986,6 +986,11 @@ Common.BrowserView {
         }
         visible: bottomEdgeHandle.enabled && !internal.hasMouse
         opacity: recentView.visible ? 0 : 1
+
+        function show() {
+            opacity = Qt.binding(function(){return recentView.visible ? 0 : 1})
+        }
+
         Behavior on opacity {
             UbuntuNumberAnimation {}
         }
@@ -998,6 +1003,31 @@ Common.BrowserView {
             color: theme.palette.normal.backgroundText
             // TRANSLATORS: %1 refers to the current number of tabs opened
             text: i18n.tr("(%1)").arg(tabsModel ? tabsModel.count : 0)
+        }
+
+        Timer {
+            id: autohideTimer
+            interval: 2000
+            onTriggered: {
+                bottomEdgeHint.opacity = 0
+            }
+        }
+        
+        Connections {
+            target: currentWebview ? currentWebview : null
+            onScrollPositionChanged: {
+                bottomEdgeHint.show()
+                autohideTimer.restart()
+            }
+        }
+        
+        Connections {
+            target: browser
+            
+            onCurrentWebviewChanged: {
+                autohideTimer.stop()
+                bottomEdgeHint.show()
+            }
         }
     }
 


### PR DESCRIPTION
Behavior of the bottom edge hint
- Hides after 2 seconds of not scrolling
- Always shown while scrolling
- Initially won't auto-hide until the webview is scrolled the first time (same behavior after switching to a tab)