### PR TITLE
Create ActionList after the place that refers it

### DIFF
--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -442,6 +442,38 @@ WebView {
                          : (fitsAbove && ! selectionVerticallyOutOfSight && ! domElementOfContextMenu.isDocumentElement) ? (bounds.y - contextMenuStartScroll.y / scaleFactor - spacing - height - (webViewScrollPosition.y - contextMenuStartScroll.y) / scaleFactor)
                                      : (webview.height - height) / 2
 
+            MouseArea {
+                // without that MouseArea the user can click "through" actions with enabled=false (e.g. accidently change the text selection)
+                anchors.fill: touchSelectionActionsRow
+                onClicked: console.log("inactive touch selection item clicked.")
+            }
+
+            Row {
+                id: touchSelectionActionsRow
+                x: parent.padding
+                y: parent.padding
+                height: units.gu(6)
+
+                Repeater {
+                    model: touchSelectionActions.children
+                    AbstractButton {
+                        objectName: "touchSelectionAction_" + action.name
+                        anchors {
+                            top: touchSelectionActionsRow.top
+                            bottom: touchSelectionActionsRow.bottom
+                        }
+                        width: Math.max(units.gu(4), implicitWidth) + units.gu(1)
+                        action: modelData
+                        styleName: "ToolbarButtonStyle"
+                        activeFocusOnPress: false
+                    }
+                }
+            }
+
+            /*
+             * ActionList is created later to workaround QObject children
+             * destruction order which destruct in creation order.
+             */
             ActionList {
                 id: touchSelectionActions
 
@@ -662,34 +694,6 @@ WebView {
                     visible: enabled
                     onTriggered: {
                         quickMenu.visible = false;
-                    }
-                }
-            }
-
-            MouseArea {
-                // without that MouseArea the user can click "through" actions with enabled=false (e.g. accidently change the text selection)
-                anchors.fill: touchSelectionActionsRow
-                onClicked: console.log("inactive touch selection item clicked.")
-            }
-
-            Row {
-                id: touchSelectionActionsRow
-                x: parent.padding
-                y: parent.padding
-                height: units.gu(6)
-
-                Repeater {
-                    model: touchSelectionActions.children
-                    AbstractButton {
-                        objectName: "touchSelectionAction_" + action.name
-                        anchors {
-                            top: touchSelectionActionsRow.top
-                            bottom: touchSelectionActionsRow.bottom
-                        }
-                        width: Math.max(units.gu(4), implicitWidth) + units.gu(1)
-                        action: modelData
-                        styleName: "ToolbarButtonStyle"
-                        activeFocusOnPress: false
                     }
                 }
             }

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -447,90 +447,89 @@ WebView {
 
                 // text selection with <leafElementName> as starting point
                 function extendSelectionUpTheDom (leafElementName) {
-
                     var commandExtendSelection = "
-            var elementForTextSelection = %1;
-            var selectedLengthStart = window.getSelection().toString().length;
+                        var elementForTextSelection = %1;
+                        var selectedLengthStart = window.getSelection().toString().length;
 
-            var levelCounter = 0;
-            // go up the DOM until the selection is larger
-            while (elementForTextSelection.parentNode)
-            {
-                // select the current node
-                var range = document.createRange();
-                range.selectNode(elementForTextSelection);
-                window.getSelection().removeAllRanges();
-                window.getSelection().addRange(range);
+                        var levelCounter = 0;
+                        // go up the DOM until the selection is larger
+                        while (elementForTextSelection.parentNode)
+                        {
+                            // select the current node
+                            var range = document.createRange();
+                            range.selectNode(elementForTextSelection);
+                            window.getSelection().removeAllRanges();
+                            window.getSelection().addRange(range);
 
-                if (window.getSelection().toString().length > selectedLengthStart)
-                {
-                    break;
+                            if (window.getSelection().toString().length > selectedLengthStart)
+                            {
+                                break;
+                            }
+                            elementForTextSelection = elementForTextSelection.parentNode;
+                            levelCounter++;
+                        }
+
+                        // return array
+                        // [0] length of selection
+                        // [1] parent level at end
+                        // [2] isRootNode
+                        [window.getSelection().toString().length, levelCounter, elementForTextSelection.parentNode ? false : true]
+                    ".arg(leafElementName);
+
+                    webview.runJavaScript(commandExtendSelection,
+                        function(result) {
+                            console.log("[extendSelectionUpTheDom] java script function returned " + JSON.stringify(result))
+                            var selectedLength = result[0]
+                            var parentLevelAtEnd = result[1]
+                            var isRootNode = result[2]
+                            quickMenu.selectedTextLength = selectedLength
+                            while (quickMenu.textSelectionLevels.length > 0 && (parentLevelAtEnd <= quickMenu.textSelectionLevels[quickMenu.textSelectionLevels.length - 1] ))
+                            {
+                                quickMenu.textSelectionLevels.pop()
+                            }
+                            quickMenu.textSelectionLevels.push(parentLevelAtEnd)
+                            quickMenu.textSelectionLevelsChanged()
+                            console.log("quickMenu.textSelectionLevels is now " + JSON.stringify(quickMenu.textSelectionLevels))
+                            quickMenu.textSelectionIsAtRootLevel = isRootNode
+                       });
                 }
-                elementForTextSelection = elementForTextSelection.parentNode;
-                levelCounter++;
-            }
 
-            // return array
-            // [0] length of selection
-            // [1] parent level at end
-            // [2] isRootNode
-            [window.getSelection().toString().length, levelCounter, elementForTextSelection.parentNode ? false : true]
-            ".arg(leafElementName);
-
-            webview.runJavaScript(commandExtendSelection,
-                                  function(result) {
-                                      console.log("[extendSelectionUpTheDom] java script function returned " + JSON.stringify(result))
-                                      var selectedLength = result[0]
-                                      var parentLevelAtEnd = result[1]
-                                      var isRootNode = result[2]
-                                      quickMenu.selectedTextLength = selectedLength
-                                      while (quickMenu.textSelectionLevels.length > 0 && (parentLevelAtEnd <= quickMenu.textSelectionLevels[quickMenu.textSelectionLevels.length - 1] ))
-                                      {
-                                          quickMenu.textSelectionLevels.pop()
-                                      }
-                                      quickMenu.textSelectionLevels.push(parentLevelAtEnd)
-                                      quickMenu.textSelectionLevelsChanged()
-                                      console.log("quickMenu.textSelectionLevels is now " + JSON.stringify(quickMenu.textSelectionLevels))
-                                      quickMenu.textSelectionIsAtRootLevel = isRootNode
-                                 });
-            }
-
-            // <parentLevel> how many levels (.parentNode calls) to go up to reach the node with the text selection in the DOM
-            // <leafElementName> is the starting point (element the context menu was created for)
-            function setTextSelection (leafElementName, parentLevel) {
+                // <parentLevel> how many levels (.parentNode calls) to go up to reach the node with the text selection in the DOM
+                // <leafElementName> is the starting point (element the context menu was created for)
+                function setTextSelection (leafElementName, parentLevel) {
 
                     var commandSetTextSelection = "
-            var elementForTextSelection = %1;
-            var parentLevel = %2;
+                        var elementForTextSelection = %1;
+                        var parentLevel = %2;
 
-            var levelCounter = 0;
-            while (elementForTextSelection.parentNode && (levelCounter < parentLevel))
-            {
-                elementForTextSelection = elementForTextSelection.parentNode;
-                levelCounter++;
-            }
+                        var levelCounter = 0;
+                        while (elementForTextSelection.parentNode && (levelCounter < parentLevel))
+                        {
+                            elementForTextSelection = elementForTextSelection.parentNode;
+                            levelCounter++;
+                        }
 
-            var range = document.createRange();
-            range.selectNode(elementForTextSelection);
-            window.getSelection().removeAllRanges();
-            window.getSelection().addRange(range);
+                        var range = document.createRange();
+                        range.selectNode(elementForTextSelection);
+                        window.getSelection().removeAllRanges();
+                        window.getSelection().addRange(range);
 
-            // return length of selection
-            window.getSelection().toString().length
-            ".arg(leafElementName).arg(parentLevel);
+                        // return length of selection
+                        window.getSelection().toString().length
+                    ".arg(leafElementName).arg(parentLevel);
 
-            webview.runJavaScript(commandSetTextSelection,
-                                  function(result) {
-                                      console.log("the length of selection is now " + result)
-                                      quickMenu.selectedTextLength = result
-                                      quickMenu.textSelectionLevels.pop()
-                                      quickMenu.textSelectionLevelsChanged()
-                                      console.log("quickMenu.textSelectionLevels is now " + JSON.stringify(quickMenu.textSelectionLevels))
-                                      quickMenu.textSelectionIsAtRootLevel = false
-                                  });
-            }
+                    webview.runJavaScript(commandSetTextSelection,
+                        function(result) {
+                            console.log("the length of selection is now " + result)
+                            quickMenu.selectedTextLength = result
+                            quickMenu.textSelectionLevels.pop()
+                            quickMenu.textSelectionLevelsChanged()
+                            console.log("quickMenu.textSelectionLevels is now " + JSON.stringify(quickMenu.textSelectionLevels))
+                            quickMenu.textSelectionIsAtRootLevel = false
+                        });
+                }
 
-            Action {
+                Action {
                     name: "undo"
                     text: i18n.dtr('ubuntu-ui-toolkit', "Undo")
                     iconName: "edit-undo"

--- a/src/app/ZoomControls.qml
+++ b/src/app/ZoomControls.qml
@@ -29,6 +29,32 @@ UbuntuShape {
         anchors.fill: menu
     }
 
+    Row {
+        id: zoomActionsRow
+        x: parent.padding
+        y: parent.padding
+        height: units.gu(6)
+
+        Repeater {
+            model: zoomActions.children
+            AbstractButton {
+                objectName: "pageAction_" + action.name
+                anchors {
+                    top: parent.top
+                    bottom: parent.bottom
+                }
+                width: Math.max(units.gu(4), implicitWidth) + units.gu(1)
+                action: modelData
+                styleName: "ToolbarButtonStyle"
+                activeFocusOnPress: false
+            }
+        }
+    }
+
+    /*
+     * ActionList is created later to workaround QObject children
+     * destruction order which destruct in creation order.
+     */
     ActionList {
         id: zoomActions
         Action {
@@ -65,28 +91,6 @@ UbuntuShape {
             iconName: "close"
             enabled: true
             onTriggered: menu.visible = false
-        }
-    }
-
-    Row {
-        id: zoomActionsRow
-        x: parent.padding
-        y: parent.padding
-        height: units.gu(6)
-
-        Repeater {
-            model: zoomActions.children
-            AbstractButton {
-                objectName: "pageAction_" + action.name
-                anchors {
-                    top: parent.top
-                    bottom: parent.bottom
-                }
-                width: Math.max(units.gu(4), implicitWidth) + units.gu(1)
-                action: modelData
-                styleName: "ToolbarButtonStyle"
-                activeFocusOnPress: false
-            }
         }
     }
 

--- a/src/app/webbrowser/AddressBar.qml
+++ b/src/app/webbrowser/AddressBar.qml
@@ -329,6 +329,32 @@ FocusScope {
             onClicked: console.log("inactive part of address bar menu clicked.")
         }
 
+        Row {
+            id: addressBarActionsRow
+            x: parent.padding
+            y: parent.padding
+            height: units.gu(6)
+
+            Repeater {
+                model: addressBarActions.children
+                AbstractButton {
+                    objectName: "addressBarAction_" + action.name
+                    anchors {
+                        top: parent.top
+                        bottom: parent.bottom
+                    }
+                    width: Math.max(units.gu(4), implicitWidth) + units.gu(2)
+                    action: modelData
+                    styleName: "ToolbarButtonStyle"
+                    activeFocusOnPress: false
+                }
+            }
+        }
+
+        /*
+         * ActionList is created later to workaround QObject children
+         * destruction order which destruct in creation order.
+         */
         ActionList {
             id: addressBarActions
             Action {
@@ -373,28 +399,6 @@ FocusScope {
                 onTriggered: {
                     textField.text = Clipboard.data.text;
                     textField.accepted();
-                }
-            }
-        }
-
-        Row {
-            id: addressBarActionsRow
-            x: parent.padding
-            y: parent.padding
-            height: units.gu(6)
-
-            Repeater {
-                model: addressBarActions.children
-                AbstractButton {
-                    objectName: "addressBarAction_" + action.name
-                    anchors {
-                        top: parent.top
-                        bottom: parent.bottom
-                    }
-                    width: Math.max(units.gu(4), implicitWidth) + units.gu(2)
-                    action: modelData
-                    styleName: "ToolbarButtonStyle"
-                    activeFocusOnPress: false
                 }
             }
         }


### PR DESCRIPTION
This is to workaround QObject children destruction order which destructs
in creation order. Otherwise, the ActionList and its children would be
destroyed before e.g. the Repeater, which will cause SIGSEGV at exit
when the Repeater is subsequently destroyed.

I don't understand why it's done this way; I would expect objects
declaratively created to be destroyed in the reverse order, in the same
way objects created on the stack in C++ would.

Also contains a code cleanup in a separate commit.