### PR TITLE
webview height and zoom fix

### DIFF
--- a/src/app/ZoomControls.qml
+++ b/src/app/ZoomControls.qml
@@ -175,7 +175,7 @@ UbuntuShape {
         // To keep webview.zoomFactor in sync with currentZoomFactor.
         onCurrentZoomFactorChanged: {
             //console.log("[ZC] controller.onCurrentZoomFactorChanged: %1".arg(controller.currentZoomFactor));
-            webview.zoomFactor = controller.currentZoomFactor;
+            internal.setWebviewZoomFactor(controller.currentZoomFactor);
         }
     }
 
@@ -286,6 +286,16 @@ UbuntuShape {
             //console.log("[ZC]   currentZoomFactor: %1".arg(controller.currentZoomFactor));
         }
 
+        function setWebviewZoomFactor(newZoomFactor) {
+            if (Math.abs(webview.zoomFactor - newZoomFactor) > 0.01) {
+               //https://bugreports.qt.io/browse/QTBUG-84313
+               // zoom is not set reliably on the first change
+               // set it twice so that changes are not ignored
+               webview.zoomFactor = newZoomFactor;
+               webview.zoomFactor = newZoomFactor;
+            }
+        }
+
         function updateFitToWidth() {
             //console.log("[ZC] internal.updateFitToWidth called");
 
@@ -315,7 +325,7 @@ UbuntuShape {
 
             //console.log("[ZC]   zooming to default and autofitting");
             // Automatic fit to width is done from defaultZoomFactor
-            webview.zoomFactor = controller.defaultZoomFactor;
+            internal.setWebviewZoomFactor(controller.defaultZoomFactor);
             // Wait, to be sure that any page layout change (css, js, ...) after previous zoom or width change takes effect.
             internal.updateFitToWidthTimer.restart();
         }
@@ -336,7 +346,7 @@ UbuntuShape {
                     if (width === null || width <= 0) {
                         //console.log("[ZC]   no scrollWidth");
                         // Sync zoom factors in case they are out of sync.
-                        webview.zoomFactor = currentZoomFactor;
+                        internal.setWebviewZoomFactor(controller.currentZoomFactor);
                         return;
                     }
 
@@ -347,7 +357,7 @@ UbuntuShape {
                     if (Math.abs(controller.currentZoomFactor - controller.fitToWidthZoomFactor) < 0.1) {
                         //console.log("[ZC]   not autofitting, close to currentZoomFactor");
                         // Sync zoom factors in case they are out of sync.
-                        webview.zoomFactor = controller.currentZoomFactor;
+                        internal.setWebviewZoomFactor(controller.currentZoomFactor);
                         return;
                     }
 
@@ -403,7 +413,7 @@ UbuntuShape {
 
                 // This is a workaround, because sometimes a page is not zoomed after loading (happens after manual url change),
                 // although the webview.zoomFactor (and currentZoomFactor) is correctly set.
-                webview.zoomFactor = controller.currentZoomFactor;
+                internal.setWebviewZoomFactor(controller.currentZoomFactor);
                 // End of workaround.
 
                 if (webview.visible === false) {

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -360,7 +360,8 @@ Common.BrowserView {
                 right: parent.right
                 top: parent.top
             }
-            height: parent.height - osk.height - bottomEdgeBar.height
+            // make sure the height is an integer value, with high DPI scale enabled osk.height is not always an integer
+            height: Math.round(parent.height - osk.height - bottomEdgeBar.height)
             // disable when newTabView is shown otherwise webview can capture drag events
             // do not use visible otherwise when a new tab is opened the locationBarController.offset
             // doesn't get updated, causing the Chrome to disappear

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -213,7 +213,8 @@ Common.BrowserView {
                 right: parent.right
                 top: chromeLoader.bottom
             }
-            height: parent.height - osk.height
+            // make sure the height is an integer value, with high DPI scale enabled osk.height is not always an integer
+            height: Math.round(parent.height - osk.height - chromeLoader.item.height)
             developerExtrasEnabled: webapp.developerExtrasEnabled
 
             focus: true


### PR DESCRIPTION
fixes https://github.com/ubports/morph-browser/issues/341

- round height of the webview to an integer value (credits to @UniversalSuperBox)
- webcontainer: consider the chrome for the webview height
- workaround for zoom changes (https://bugreports.qt.io/browse/QTBUG-84313)