### PR TITLE
Round height of WebEngineViews

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -360,7 +360,9 @@ Common.BrowserView {
                 right: parent.right
                 top: parent.top
             }
-            height: parent.height - osk.height - bottomEdgeBar.height
+
+            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
+            height: Math.round(parent.height - osk.height - bottomEdgeBar.height)
             // disable when newTabView is shown otherwise webview can capture drag events
             // do not use visible otherwise when a new tab is opened the locationBarController.offset
             // doesn't get updated, causing the Chrome to disappear

--- a/src/app/webcontainer/PopupWindowController.qml
+++ b/src/app/webcontainer/PopupWindowController.qml
@@ -223,7 +223,8 @@ Item {
         PopupWindowOverlay {
             id: overlay
 
-            height: parent.height
+            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
+            height: Math.round(parent.height)
             width: parent.width
 
             wide: controller.wide

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -213,7 +213,8 @@ Common.BrowserView {
                 right: parent.right
                 top: chromeLoader.bottom
             }
-            height: parent.height - osk.height
+            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
+            height: Math.round(parent.height - osk.height)
             developerExtrasEnabled: webapp.developerExtrasEnabled
 
             focus: true


### PR DESCRIPTION
Work around a bizarre issue in QtWebEngine by rounding the height of any WebEngineView objects.

@balcy, are you aware of any more instances of WebViews being instanciated inside the morph code?

Works around https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38

Fixes https://github.com/ubports/morph-browser/issues/341 and therefore fixes https://github.com/ubports/ubuntu-touch/issues/1519