### PR TITLE
Update WebApp.qml

### DIFF
--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -214,7 +214,7 @@ Common.BrowserView {
                 top: chromeLoader.bottom
             }
             // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
-            height: Math.round(parent.height - osk.height)
+            height: Math.round(parent.height - osk.height - chromeLoader.item.height)
             developerExtrasEnabled: webapp.developerExtrasEnabled
 
             focus: true


### PR DESCRIPTION
subtract height of the chrome from the height of the WebApp. (otherwise the bottom is cut off)
fixes https://github.com/ubports/morph-browser/issues/338