### PR TITLE
remove the setting of QTWEBENGINE_CHROMIUM_FLAGS, because they are al…

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -361,8 +361,7 @@ Common.BrowserView {
                 top: parent.top
             }
 
-            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
-            height: Math.round(parent.height - osk.height - bottomEdgeBar.height)
+            height: parent.height - osk.height - bottomEdgeBar.height
             // disable when newTabView is shown otherwise webview can capture drag events
             // do not use visible otherwise when a new tab is opened the locationBarController.offset
             // doesn't get updated, causing the Chrome to disappear

--- a/src/app/webbrowser/morph-browser.cpp
+++ b/src/app/webbrowser/morph-browser.cpp
@@ -162,11 +162,6 @@ void WebbrowserApp::onNewInstanceLaunched(const QStringList& arguments) const
 int main(int argc, char** argv)
 {
     qputenv("QTWEBENGINE_DISABLE_SANDBOX","1");
-    // disable gpu and viz display compositor
-    if (qgetenv("QTWEBENGINE_CHROMIUM_FLAGS") == QString())
-    {
-        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu --disable-viz-display-compositor");
-    }
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "true");
 
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);

--- a/src/app/webcontainer/PopupWindowController.qml
+++ b/src/app/webcontainer/PopupWindowController.qml
@@ -223,8 +223,7 @@ Item {
         PopupWindowOverlay {
             id: overlay
 
-            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
-            height: Math.round(parent.height)
+            height: parent.height
             width: parent.width
 
             wide: controller.wide

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -213,8 +213,7 @@ Common.BrowserView {
                 right: parent.right
                 top: chromeLoader.bottom
             }
-            // https://github.com/ubports/qtwebengine-opensource-src-packaging/issues/38
-            height: Math.round(parent.height - osk.height - chromeLoader.item.height)
+            height: parent.height - osk.height - chromeLoader.item.height
             developerExtrasEnabled: webapp.developerExtrasEnabled
 
             focus: true

--- a/src/app/webcontainer/webapp-container.cpp
+++ b/src/app/webcontainer/webapp-container.cpp
@@ -520,11 +520,6 @@ void WebappContainer::onNewInstanceLaunched(const QStringList& arguments) const
 int main(int argc, char** argv)
 {
     qputenv("QTWEBENGINE_DISABLE_SANDBOX","1");
-    // disable gpu and viz display compositor
-    if (qgetenv("QTWEBENGINE_CHROMIUM_FLAGS") == QString())
-    {
-        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu --disable-viz-display-compositor");
-    }
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "true");
 
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);


### PR DESCRIPTION
…ready set outside of morph-browser / webapp-container

setting them here can lead to situations where morph-browser / webapp-container do work, but other apps not, and any changes have to be made at several locations
see https://github.com/ubports/lxc-android-config/blob/xenial/etc/profile.d/disable-qtwebengine-gpu.sh

- undo the roundings