### PR TITLE
Restore custom user agents / add "always deny" for location access

### DIFF
--- a/src/Morph/Web/MorphWebContext.qml
+++ b/src/Morph/Web/MorphWebContext.qml
@@ -26,6 +26,8 @@ WebEngineProfile {
     property alias dataPath: oxideContext.persistentStoragePath
     property alias maxCacheSizeHint: oxideContext.httpCacheMaximumSize
     property alias incognito: oxideContext.offTheRecord
+    property int userAgentId: 0
+    property string customUserAgent: ""
     readonly property string defaultUserAgent: __ua.defaultUA
 
     offTheRecord: false
@@ -35,7 +37,7 @@ WebEngineProfile {
     cachePath: cacheLocation
     maxCacheSizeHint: cacheSizeHint
 
-    userAgent: defaultUserAgent
+    userAgent: (customUserAgent !== "") ? customUserAgent : defaultUserAgent
 
     persistentCookiesPolicy: WebEngineProfile.ForcePersistentCookies
 

--- a/src/app/DomainSettingsPage.qml
+++ b/src/app/DomainSettingsPage.qml
@@ -17,6 +17,7 @@
  */
 
 import QtQuick 2.6
+import QtQuick.Controls 2.2
 import Qt.labs.settings 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
@@ -169,6 +170,7 @@ FocusScope {
                 readonly property bool isCurrentItem: item.ListView.isCurrentItem
                 readonly property string domain: model.domain
                 readonly property int userAgentId: model.userAgentId
+                readonly property int locationPreference: model.allowLocation
                 height: isCurrentItem ? layout.height : units.gu(5)
                 color: isCurrentItem ? ((theme.palette.selected.background.hslLightness > 0.5) ? Qt.darker(theme.palette.selected.background, 1.05) : Qt.lighter(theme.palette.selected.background, 1.5)) : theme.palette.normal.background
 
@@ -203,14 +205,35 @@ FocusScope {
                             Label  {
                                 width: parent.width * 0.9
                                 text: i18n.tr("allowed to launch other apps")
+                                anchors.verticalCenter: parent.verticalCenter
                             }
 
                             CheckBox {
                                 checked: model.allowCustomUrlSchemes
                                 onTriggered: DomainSettingsModel.allowCustomUrlSchemes(model.domain, checked)
+                                anchors.verticalCenter: parent.verticalCenter
                             }
                         }
 
+
+                        Row {
+                            spacing: units.gu(1.5)
+                            height: units.gu(1)
+                            visible: item.ListView.isCurrentItem
+
+                            Label  {
+                                width: parent.width * 0.5
+                                text: i18n.tr("access your location")
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            ComboBox {
+                               model: [ i18n.tr("Ask each time"), i18n.tr("Allowed"), i18n.tr("Denied") ]
+                               currentIndex: item.locationPreference
+                               onCurrentIndexChanged: DomainSettingsModel.setLocationPreference(item.domain, currentIndex)
+                               anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
 
                         Row {
                             spacing: units.gu(1.5)
@@ -219,23 +242,9 @@ FocusScope {
 
                             Label  {
                                 width: parent.width * 0.9
-                                text: i18n.tr("allowed to access your location")
-                            }
-
-                            CheckBox {
-                                checked: model.allowLocation
-                                onTriggered: DomainSettingsModel.allowLocation(model.domain, checked)
-                            }
-                        }
-
-                        Row {
-                            spacing: units.gu(1.5)
-                            height: units.gu(1)
-                            visible: item.ListView.isCurrentItem
-
-                            Label  {
                                 text: i18n.tr("custom user agent")
                                 opacity: UserAgentsModel.count > 0 ? 1.0 : 0.5
+                                anchors.verticalCenter: parent.verticalCenter
                             }
 
                             CheckBox {
@@ -260,6 +269,7 @@ FocusScope {
                                         DomainSettingsModel.setUserAgentId(model.domain, 0);
                                     }
                                 }
+                                anchors.verticalCenter: parent.verticalCenter
                             }
                         }
 
@@ -307,16 +317,22 @@ FocusScope {
                             }
                         }
 
-                        // within one label the check if zoom factor is set could not be properly done
-                        Label  {
+                        Row {
+                            spacing: units.gu(1.5)
                             height: units.gu(1)
-                            text: i18n.tr("Zoom: ") + Math.round(model.zoomFactor * 100) + "%"
-                            visible: item.ListView.isCurrentItem && ! isNaN(model.zoomFactor)
-                        }
-                        Label  {
-                            height: units.gu(1)
-                            text: i18n.tr("Zoom: ") + i18n.tr("not set")
-                            visible: item.ListView.isCurrentItem && isNaN(model.zoomFactor)
+                            visible: item.ListView.isCurrentItem
+
+                            // within one label the check if zoom factor is set could not be properly done
+                            Label  {
+                                text: i18n.tr("Zoom: ") + Math.round(model.zoomFactor * 100) + "%"
+                                visible: ! isNaN(model.zoomFactor)
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            Label  {
+                                text: i18n.tr("Zoom: ") + i18n.tr("not set")
+                                visible: isNaN(model.zoomFactor)
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
                         }
                     }
                 }

--- a/src/app/DomainSettingsPage.qml
+++ b/src/app/DomainSettingsPage.qml
@@ -143,8 +143,7 @@ FocusScope {
         ListItem {
             id: useragentsMenu
             z: 3
-            // custom user agents deactivated for now
-            height: 0 //units.gu(6)
+            height: units.gu(6)
             color: theme.palette.normal.background
             ListItemLayout {
                 title.text: i18n.tr("Custom User Agents")
@@ -232,8 +231,7 @@ FocusScope {
                         Row {
                             spacing: units.gu(1.5)
                             height: units.gu(1)
-                            // deactivated for now
-                            visible: false //item.ListView.isCurrentItem
+                            visible: item.ListView.isCurrentItem
 
                             Label  {
                                 text: i18n.tr("custom user agent")

--- a/src/app/DomainSettingsPage.qml
+++ b/src/app/DomainSettingsPage.qml
@@ -252,17 +252,17 @@ FocusScope {
                                 enabled: UserAgentsModel.count > 0
                                 checked: model.userAgentId > 0
                                 onTriggered: {
-                                    optSelect.selectedIndex = -1;
+                                    userAgentSelect.currentIndex = -1;
 
                                     if (checked) {
-                                        if( UserAgentsModel.count === 1)
+                                        if(UserAgentsModel.count === 1)
                                         {
-                                            optSelect.selectedIndex = 0;
-                                            DomainSettingsModel.setUserAgentId(item.domain, optSelect.model.get(optSelect.selectedIndex).id);
+                                            userAgentSelect.currentIndex = 0;
+                                            DomainSettingsModel.setUserAgentId(item.domain, userAgentSelect.model.get(userAgentSelect.currentIndex).id);
                                         }
                                         else
                                         {
-                                            optSelect.currentlyExpanded = true;
+                                            userAgentSelect.onPressedChanged();
                                         }
                                     }
                                     else  {
@@ -273,13 +273,9 @@ FocusScope {
                             }
                         }
 
-                        /* ToDo: Can we do sth. about the following log messages ?
-                               file:///usr/lib/arm-linux-gnueabihf/qt5/qml/Ubuntu/Components/1.3/OptionSelector.qml:330:13:
-                               QML ListView: Binding loop detected for property "itemHeight"
-                            */
-                        OptionSelector {
+                        ComboBox {
 
-                            id: optSelect
+                            id: userAgentSelect
                             visible: customUserAgentCheckbox.checked
                             enabled: (UserAgentsModel.count > 1)
 
@@ -289,15 +285,14 @@ FocusScope {
                                 sort.property: "name"
                                 sort.order: Qt.AscendingOrder
                             }
-                            delegate: OptionSelectorDelegate {
-                                text: model.name
-                            }
-
+                            
+                            textRole: "name"
+                            
                             function updateIndex() {
                                 for (var i = 0; i < model.count; ++i) {
                                     if (item.userAgentId === model.get(i).id)
                                     {
-                                        selectedIndex = i;
+                                        currentIndex = i;
                                     }
                                 }
                             }
@@ -307,14 +302,12 @@ FocusScope {
 
                                 onIsCurrentItemChanged: {
                                     if (item.isCurrentItem && (item.userAgentId > 0)) {
-                                        optSelect.updateIndex();
+                                        userAgentSelect.updateIndex();
                                     }
                                 }
                             }
-
-                            onDelegateClicked: {
-                                DomainSettingsModel.setUserAgentId(item.domain, model.get(index).id);
-                            }
+                            
+                            onActivated: DomainSettingsModel.setUserAgentId(item.domain, model.get(index).id);
                         }
 
                         Row {
@@ -367,13 +360,6 @@ FocusScope {
             horizontalAlignment: Text.AlignHCenter
             text: i18n.tr("No domain specific settings available")
         }
-
-        Connections {
-            target: UserAgentsModel
-            enabled: ! customUserAgentsViewLoader.active
-            // the OptionSelector does not properly update the model (duplicate entries instead of new user agents)
-            onRowCountChanged: reload()
-        }
     }
 
     Loader {
@@ -395,10 +381,6 @@ FocusScope {
             onReload: {
                 customUserAgentsViewLoader.active = false;
                 customUserAgentsViewLoader.active = true;
-
-                if (selectedUserAgent) {
-                    customUserAgentsViewLoader.item.setUserAgentAsCurrentItem(selectedUserAgent)
-                }
             }
         }
     }

--- a/src/app/EditCustomUserAgentDialog.qml
+++ b/src/app/EditCustomUserAgentDialog.qml
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 UBports Foundation
+ *
+ * This file is part of morph-browser.
+ *
+ * morph-browser is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * morph-browser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import Ubuntu.Components 1.3 as UITK
+import Ubuntu.Components.Popups 1.3 as Popups
+import Ubuntu.Content 1.3
+import webbrowsercommon.private 0.1
+
+Popups.Dialog {
+    id: editCustomUserAgent
+
+    property string previousUserAgentName: ""
+    property alias userAgentName: editUserAgentName.text
+    property alias userAgentString: editUserAgentString.text
+
+    readonly property bool userAgentNameAlreadyTaken: (userAgentName !== previousUserAgentName) && UserAgentsModel.contains(userAgentName)
+
+    signal accept(string userAgentName, string userAgentString)
+    signal cancel()
+
+    onAccept: hide()
+    onCancel: hide()
+
+    UITK.Label {
+        visible: userAgentNameAlreadyTaken
+        text: i18n.tr("this user agent name is already taken")
+        color: theme.palette.normal.negative
+    }
+
+    UITK.TextField {
+        id: editUserAgentName
+        placeholderText: i18n.tr("Add the name for the user agent")
+        inputMethodHints: Qt.ImhNoPredictiveText
+    }
+
+    UITK.TextArea {
+        id: editUserAgentString
+        placeholderText: i18n.tr("enter user agent string...")
+        inputMethodHints: Qt.ImhNoPredictiveText
+    }
+
+    Row {
+        spacing: units.gu(2)
+
+        UITK.Button {
+            text: i18n.tr("OK")
+            color: theme.palette.normal.positive
+            enabled: (userAgentName !== "") && ! userAgentNameAlreadyTaken
+            onClicked: accept(userAgentName, userAgentString)
+        }
+
+        UITK.Button {
+            text: i18n.tr("Cancel")
+            onClicked: cancel()
+        }
+    }
+}

--- a/src/app/GeolocationPermissionRequest.qml
+++ b/src/app/GeolocationPermissionRequest.qml
@@ -24,7 +24,7 @@ Dialog {
     id: dialog
 
     property string securityOrigin
-    property bool showAllowPermanentlyCheckBox
+    property bool showRememberDecisionCheckBox
 
     title: i18n.tr("Permission Request")
     text: securityOrigin + "<br>" + i18n.tr("This page wants to know your device’s location.")
@@ -32,28 +32,29 @@ Dialog {
     signal allow()
     signal allowPermanently()
     signal reject()
+    signal rejectPermanently()
     
     onAllow: { PopupUtils.close(dialog); }
     onAllowPermanently: { PopupUtils.close(dialog); }
     onReject: { PopupUtils.close(dialog); }
+    onRejectPermanently: { PopupUtils.close(dialog); }
 
     ListItemLayout {
-        visible: showAllowPermanentlyCheckBox
+        visible: showRememberDecisionCheckBox
         title.text: i18n.tr("Remember decision")
         CheckBox {
-            id: allowPermanentlyCheckBox
+            id: rememberDecisionCheckBox
          }
     }
     Button {
         objectName: "allow"
         text: i18n.tr("Allow")
         color: theme.palette.normal.positive
-        onClicked: allowPermanentlyCheckBox.checked ? allowPermanently() : allow()
+        onClicked: rememberDecisionCheckBox.checked ? allowPermanently() : allow()
     }
     Button {
         objectName: "deny"
         text: i18n.tr("Deny")
-        enabled: ! allowPermanentlyCheckBox.checked
-        onClicked: reject()
+        onClicked: rememberDecisionCheckBox.checked ? rejectPermanently() : reject()
     }
 }

--- a/src/app/WebViewImpl.qml
+++ b/src/app/WebViewImpl.qml
@@ -196,21 +196,31 @@ WebView {
              case WebEngineView.Geolocation:
 
              var domain = UrlUtils.extractHost(securityOrigin);
+             var locationPreference = DomainSettingsModel.getLocationPreference(domain);
 
-             if (DomainSettingsModel.isLocationAllowed(domain))
+             if (locationPreference === DomainSettingsModel.AllowLocationAccess)
              {
                  grantFeaturePermission(securityOrigin, feature, true);
                  return;
              }
 
+             if (locationPreference === DomainSettingsModel.DenyLocationAccess)
+             {
+                 grantFeaturePermission(securityOrigin, feature, false);
+                 return;
+             }
+
              var geoPermissionDialog = PopupUtils.open(Qt.resolvedUrl("GeolocationPermissionRequest.qml"), this);
              geoPermissionDialog.securityOrigin = securityOrigin;
-             geoPermissionDialog.showAllowPermanentlyCheckBox = (domain !== "") && ! incognito
+             geoPermissionDialog.showRememberDecisionCheckBox = (domain !== "") && ! incognito
              geoPermissionDialog.allow.connect(function() { grantFeaturePermission(securityOrigin, feature, true); });
              geoPermissionDialog.allowPermanently.connect(function() { grantFeaturePermission(securityOrigin, feature, true);
-                                                                       DomainSettingsModel.allowLocation(domain, true);
+                                                                       DomainSettingsModel.setLocationPreference(domain, DomainSettingsModel.AllowLocationAccess);
                                                                      })
              geoPermissionDialog.reject.connect(function() { grantFeaturePermission(securityOrigin, feature, false); });
+             geoPermissionDialog.rejectPermanently.connect(function() { grantFeaturePermission(securityOrigin, feature, false);
+                                                                       DomainSettingsModel.setLocationPreference(domain, DomainSettingsModel.DenyLocationAccess);
+                                                                     })
              break;
 
              case WebEngineView.MediaAudioCapture:

--- a/src/app/domain-permissions-model.h
+++ b/src/app/domain-permissions-model.h
@@ -32,6 +32,7 @@ class DomainPermissionsModel : public QAbstractListModel
     Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(bool whiteListMode READ whiteListMode WRITE setWhiteListMode NOTIFY whiteListModeChanged)
 
+    Q_ENUMS(DomainPermission)
     Q_ENUMS(Roles)
 
 public:
@@ -43,7 +44,6 @@ public:
         Blocked = 1,
         Whitelisted = 2
     };
-    Q_ENUMS(DomainPermission)
 
     enum Roles {
         Domain = Qt::UserRole + 1,

--- a/src/app/domain-settings-model.cpp
+++ b/src/app/domain-settings-model.cpp
@@ -111,7 +111,7 @@ void DomainSettingsModel::createOrAlterDatabaseSchema()
 {
     QSqlQuery createQuery(m_database);
     QString query = QLatin1String("CREATE TABLE IF NOT EXISTS domainsettings "
-                                  "(domain VARCHAR NOT NULL UNIQUE, domainWithoutSubdomain VARCHAR, allowCustomUrlSchemes BOOL, allowLocation BOOL, "
+                                  "(domain VARCHAR NOT NULL UNIQUE, domainWithoutSubdomain VARCHAR, allowCustomUrlSchemes BOOL, allowLocation INTEGER, "
                                   "userAgentId INTEGER, zoomFactor REAL, PRIMARY KEY(domain), FOREIGN KEY(userAgentId) REFERENCES useragents(id)); ");
     createQuery.prepare(query);
     createQuery.exec();
@@ -130,7 +130,7 @@ void DomainSettingsModel::populateFromDatabase()
         entry.domain = populateQuery.value("domain").toString();
         entry.domainWithoutSubdomain = populateQuery.value("domainWithoutSubdomain").toString();
         entry.allowCustomUrlSchemes = populateQuery.value("allowCustomUrlSchemes").toBool();
-        entry.allowLocation = populateQuery.value("allowLocation").toBool();
+        entry.allowLocation = static_cast<AllowLocationPreference>(populateQuery.value("allowLocation").toInt());
         entry.userAgentId = populateQuery.value("userAgentId").toInt();
         entry.zoomFactor =  populateQuery.value("zoomFactor").isNull() ? std::numeric_limits<double>::quiet_NaN()
                                                                        : populateQuery.value("zoomFactor").toDouble();
@@ -215,33 +215,33 @@ void DomainSettingsModel::allowCustomUrlSchemes(const QString& domain, bool allo
     }
 }
 
-bool DomainSettingsModel::isLocationAllowed(const QString& domain) const
+DomainSettingsModel::AllowLocationPreference DomainSettingsModel::getLocationPreference(const QString& domain) const
 {
     int index = getIndexForDomain(domain);
     if (index == -1)
     {
-        return false;
+        return AllowLocationPreference::AskForLocationAccess;
     }
 
     return m_entries[index].allowLocation;
 }
 
-void DomainSettingsModel::allowLocation(const QString& domain, bool allow)
+void DomainSettingsModel::setLocationPreference(const QString& domain, DomainSettingsModel::AllowLocationPreference preference)
 {
     insertEntry(domain);
 
     int index = getIndexForDomain(domain);
     if (index != -1) {
         DomainSetting& entry = m_entries[index];
-        if (entry.allowLocation == allow) {
+        if (entry.allowLocation == preference) {
             return;
         }
-        entry.allowLocation = allow;
+        entry.allowLocation = preference;
         Q_EMIT dataChanged(this->index(index, 0), this->index(index, 0), QVector<int>() << AllowLocation);
         QSqlQuery query(m_database);
         static QString updateStatement = QLatin1String("UPDATE domainsettings SET allowLocation=? WHERE domain=?;");
         query.prepare(updateStatement);
-        query.addBindValue(allow);
+        query.addBindValue(entry.allowLocation);
         query.addBindValue(domain);
         query.exec();
     }
@@ -346,7 +346,7 @@ void DomainSettingsModel::insertEntry(const QString &domain)
     entry.domain = domain;
     entry.domainWithoutSubdomain = DomainUtils::getDomainWithoutSubdomain(domain);
     entry.allowCustomUrlSchemes = false;
-    entry.allowLocation = false;
+    entry.allowLocation = AllowLocationPreference::AskForLocationAccess;
     entry.userAgentId = 0;
     entry.zoomFactor = std::numeric_limits<double>::quiet_NaN();
     m_entries.append(entry);

--- a/src/app/domain-settings-model.h
+++ b/src/app/domain-settings-model.h
@@ -23,6 +23,7 @@
 #include <QString>
 #include <QtSql/QSqlDatabase>
 
+
 class DomainSettingsModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -31,11 +32,18 @@ class DomainSettingsModel : public QAbstractListModel
     Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(double defaultZoomFactor READ defaultZoomFactor WRITE setDefaultZoomFactor)
 
+    Q_ENUMS(AllowLocationPreference)
     Q_ENUMS(Roles)
 
 public:
     DomainSettingsModel(QObject* parent=0);
     ~DomainSettingsModel();
+
+    enum AllowLocationPreference {
+     AskForLocationAccess = 0,
+     AllowLocationAccess = 1,
+     DenyLocationAccess = 2
+    };
 
     enum Roles {
         Domain = Qt::UserRole + 1,
@@ -61,8 +69,8 @@ public:
     Q_INVOKABLE void deleteAndResetDataBase();
     Q_INVOKABLE bool areCustomUrlSchemesAllowed(const QString& domain);
     Q_INVOKABLE void allowCustomUrlSchemes(const QString& domain, bool allow);
-    Q_INVOKABLE bool isLocationAllowed(const QString& domain) const;
-    Q_INVOKABLE void allowLocation(const QString& domain, bool allow);
+    Q_INVOKABLE AllowLocationPreference getLocationPreference(const QString& domain) const;
+    Q_INVOKABLE void setLocationPreference(const QString& domain, AllowLocationPreference preference);
     Q_INVOKABLE int getUserAgentId(const QString& domain) const;
     Q_INVOKABLE void setUserAgentId(const QString& domain, int userAgentId);
     Q_INVOKABLE void removeUserAgentIdFromAllDomains(int userAgentId);
@@ -84,7 +92,7 @@ private:
         QString domain;
         QString domainWithoutSubdomain;
         bool allowCustomUrlSchemes;
-        bool allowLocation;
+        AllowLocationPreference allowLocation;
         int userAgentId;
         double zoomFactor;
     };

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -274,13 +274,18 @@ Common.BrowserView {
                 {
                     currentWebview.context.userAgentId = newUserAgentId;
                     currentWebview.context.customUserAgent = (newUserAgentId > 0) ? UserAgentsModel.getUserAgentString(newUserAgentId) : "";
+
+		    // for some reason when letting through the request, another navigation request will take us back to the
+                    // to the previous page. Therefore we block it first and navigate to the new url with the correct user agent.
+                    request.action = WebEngineNavigationRequest.IgnoreRequest;
+                    currentWebview.url = url;
+                    return;
                 }
                 else
                 {
                     currentWebview.context.__ua.setDesktopMode(browser.settings ? browser.settings.setDesktopMode : false);
+                    console.log("user agent: " + currentWebview.context.httpUserAgent);
                 }
-
-                console.log("user agent: " + currentWebview.context.httpUserAgent);
             }
         }
     }

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -266,11 +266,22 @@ Common.BrowserView {
             // handle user agents
             if (isMainFrame)
             {
-                currentWebview.context.__ua.setDesktopMode(browser.settings ? browser.settings.setDesktopMode : false);
+                currentWebview.hideContextMenu();
+                var newUserAgentId = (UserAgentsModel.count > 0) ? DomainSettingsModel.getUserAgentId(requestDomain) : 0;
+
+                // change of the custom user agent
+                if (newUserAgentId !== currentWebview.context.userAgentId)
+                {
+                    currentWebview.context.userAgentId = newUserAgentId;
+                    currentWebview.context.customUserAgent = (newUserAgentId > 0) ? UserAgentsModel.getUserAgentString(newUserAgentId) : "";
+                }
+                else
+                {
+                    currentWebview.context.__ua.setDesktopMode(browser.settings ? browser.settings.setDesktopMode : false);
+                }
+
                 console.log("user agent: " + currentWebview.context.httpUserAgent);
             }
-
-            //currentWebview.showMessage(url)
         }
     }
 

--- a/src/app/webcontainer/WebViewImplOxide.qml
+++ b/src/app/webcontainer/WebViewImplOxide.qml
@@ -346,8 +346,17 @@ WebappWebview {
             webview.context.userAgentId = newUserAgentId;
             webview.context.userAgent = (newUserAgentId > 0) ? UserAgentsModel.getUserAgentString(newUserAgentId)
                                                              : localUserAgentOverride ? localUserAgentOverride : webview.context.defaultUserAgent;
+
+            // for some reason when letting through the request, another navigation request will take us back to the
+            // to the previous page. Therefore we block it first and navigate to the new url with the correct user agent.
+            request.action = WebEngineNavigationRequest.IgnoreRequest;
+            webview.url = url;
+            return;
           }
-          console.log("user agent: " + webview.context.httpUserAgent)
+          else
+          {
+              console.log("user agent: " + webview.context.httpUserAgent);
+          }
         }
 
         if (runningLocalApplication && url.indexOf("file://") !== 0) {

--- a/src/app/webcontainer/WebViewImplOxide.qml
+++ b/src/app/webcontainer/WebViewImplOxide.qml
@@ -335,6 +335,21 @@ WebappWebview {
             return;
         }
 
+        // handle user agents
+        if (isMainFrame)
+        {
+          var newUserAgentId = (UserAgentsModel.count > 0) ? DomainSettingsModel.getUserAgentId(requestDomain) : 0;
+
+          // change of the custom user agent
+          if (newUserAgentId !== webview.context.userAgentId)
+          {
+            webview.context.userAgentId = newUserAgentId;
+            webview.context.userAgent = (newUserAgentId > 0) ? UserAgentsModel.getUserAgentString(newUserAgentId)
+                                                             : localUserAgentOverride ? localUserAgentOverride : webview.context.defaultUserAgent;
+          }
+          console.log("user agent: " + webview.context.httpUserAgent)
+        }
+
         if (runningLocalApplication && url.indexOf("file://") !== 0) {
             request.action = WebEngineNavigationRequest.IgnoreRequest;
             openUrlExternally(url, true);


### PR DESCRIPTION
"Remember decision" for location access is available now for "Allow" and "Deny" (always deny was not possible before)
fixes https://github.com/ubports/morph-browser/issues/320

restore custom user agents (planned but not rolled out in https://github.com/ubports/morph-browser/pull/203), new QtWebEngine should handle them correctly (hopefully)