### PR TITLE
Set a default for offTheRecord in MorphWebContext

### DIFF
--- a/src/Morph/Web/MorphWebContext.qml
+++ b/src/Morph/Web/MorphWebContext.qml
@@ -28,6 +28,8 @@ WebEngineProfile {
     property alias incognito: oxideContext.offTheRecord
     readonly property string defaultUserAgent: __ua.defaultUA
 
+    offTheRecord: false
+
     dataPath: dataLocation
 
     cachePath: cacheLocation


### PR DESCRIPTION
QtWebEngine 5.13 changed the default value of offTheRecord from false to true. This means that apps will dump all cookies and site data on exit by default.

If someone is using the MorphWebContext as part of their app, they expect the old behavior with offTheRecord = false. So we'll just set that.

https://github.com/ubports/morph-browser/issues/347

This does not help apps which are using WebEngineProfile directly without setting offTheRecord. Those apps will need to set "offTheRecord: false" on their Profile by themselves.