### PR TITLE
Implement swipe to close tab and fix tab previews

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -559,15 +559,12 @@ Common.BrowserView {
         visible: bottomEdgeHandle.dragging || tabslist.animating || (state == "shown")
         onVisibleChanged: {
             if (visible) {
+
                 currentWebview.hideContextMenu();
                 chrome.state = "hidden";
-                currentWebview.visible = false;
-                newTabViewLoader.visible = false;
             }
             else {
                 chrome.state = "shown";
-                currentWebview.visible = true;
-                newTabViewLoader.visible = true;
             }
         }
 

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -40,6 +40,11 @@ Common.BrowserView {
 
     currentWebview: tabsModel && tabsModel.currentTab ? tabsModel.currentTab.webview : null
 
+    TabChrome {
+        id: invisibleTabChrome
+        visible: false
+    }
+
     property bool incognito: false
 
     property var tabsModel: TabsModel {
@@ -692,8 +697,8 @@ Common.BrowserView {
         property bool hidden: false
 
         Behavior on y {
-            enabled: recentView.visible
             NumberAnimation {
+                from: -chrome.height + invisibleTabChrome.height
                 duration: UbuntuAnimation.FastDuration
             }
         }

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -556,9 +556,13 @@ Common.BrowserView {
             if (visible) {
                 currentWebview.hideContextMenu();
                 chrome.state = "hidden";
+                currentWebview.visible = false;
+                newTabViewLoader.visible = false;
             }
             else {
                 chrome.state = "shown";
+                currentWebview.visible = true;
+                newTabViewLoader.visible = true;
             }
         }
 
@@ -846,7 +850,7 @@ Common.BrowserView {
         Connections {
             target: browser.currentWebview
             onLoadingChanged: {
-                if (browser.currentWebview.loading) {
+                if (browser.currentWebview.loading && !recentView.visible) {
                     chrome.state = "shown"
                 } else if (browser.currentWebview.isFullScreen) {
                     chrome.state = "hidden"

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -553,9 +553,12 @@ Common.BrowserView {
         anchors.fill: parent
         visible: bottomEdgeHandle.dragging || tabslist.animating || (state == "shown")
         onVisibleChanged: {
-            if (visible)
-            {
-                currentWebview.hideContextMenu()
+            if (visible) {
+                currentWebview.hideContextMenu();
+                chrome.state = "hidden";
+            }
+            else {
+                chrome.state = "shown";
             }
         }
 

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -93,7 +93,7 @@ Common.BrowserView {
         state.url = tab.url.toString()
         state.title = tab.title
         state.icon = tab.icon.toString()
-        state.preview = tab.preview.toString()
+        state.preview =  Qt.resolvedUrl(PreviewManager.previewPathFromUrl(tab.url))
         state.savedState = tab.webview ? tab.webview.currentState : tab.restoreState
         return state
     }

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -45,10 +45,10 @@ FocusScope {
     property bool incognito
     readonly property bool empty: !url.toString() && !initialUrl.toString() && !restoreState && !request
     property bool loadingPreview: false
-    readonly property size previewSize: Qt.size(webview.width*Screen.devicePixelRatio,
-                                                webview.height*Screen.devicePixelRatio)
-    readonly property size previewThumbnailSize: Qt.size(webview.width/1.5,
-                                                         webview.height/1.5)
+    readonly property size previewSize: webview ? Qt.size(webview.width*Screen.devicePixelRatio,
+                                                webview.height*Screen.devicePixelRatio) : Qt.size(0,0)
+    readonly property size previewThumbnailSize: webview ? Qt.size(webview.width/1.5,
+                                                         webview.height/1.5) : Qt.size(0,0)
     //store reference to preview to avoid clearing by garbage collector
     property var previewCache
     visible: false

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -201,33 +201,15 @@ FocusScope {
         }
     }
 
-    // Take a capture of the current page shortly after it has finished
-    // loading to give rendering an opportunity to complete. There is
-    // unfortunately no signal to notify us when rendering has completed.
-    Timer {
-        id: delayedCapture
-        interval: 500
-        onTriggered: {
-            if (recentView.visible)
-                return
-            if (webview && current && visible && !internal.hiding) {
+    Connections {
+        target: recentView
+        onVisibleChanged: {
+            if(visible && current && !empty && !webview.incognito) {
+                preview = ""
                 webview.grabToImage(function(result) {
                     PreviewManager.saveToDisk(result, url)
-                },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio))
+                },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio));
             }
-        }
-    }
-    Connections {
-        target: incognito ? null : webview
-        onLoadingChanged: {
-            if (!webview.loading)
-                delayedCapture.restart()
-        }
-        onScrollPositionChanged: {
-            delayedCapture.restart()
-        }
-        onWidthChanged: {
-            delayedCapture.restart()
         }
     }
 

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -47,8 +47,8 @@ FocusScope {
     property bool loadingPreview: false
     readonly property size previewSize: Qt.size(webview.width*Screen.devicePixelRatio,
                                                 webview.height*Screen.devicePixelRatio)
-    readonly property size previewThumbnailSize: Qt.size(webview.width/2,
-                                                         webview.height/2)
+    readonly property size previewThumbnailSize: Qt.size(webview.width/1.5,
+                                                         webview.height/1.5)
     //store reference to preview to avoid clearing by garbage collector
     property var previewCache
     visible: false

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -44,6 +44,7 @@ FocusScope {
     readonly property real lastCurrent: internal.lastCurrent
     property bool incognito
     readonly property bool empty: !url.toString() && !initialUrl.toString() && !restoreState && !request
+    property bool loadingPreview: false
     visible: false
 
     // Used as a workaround for https://launchpad.net/bugs/1502675 :
@@ -197,7 +198,7 @@ FocusScope {
                 visible = false
 
                 PreviewManager.saveToDisk(result, url)
-            },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio));
+            },Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),webview.height*Math.max(Screen.devicePixelRatio/2,1)));
         }
     }
 
@@ -206,9 +207,11 @@ FocusScope {
         onVisibleChanged: {
             if(visible && current && !empty && !webview.incognito) {
                 preview = ""
+                loadingPreview = true
                 webview.grabToImage(function(result) {
                     PreviewManager.saveToDisk(result, url)
-                },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio));
+                },Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),webview.height*Math.max(Screen.devicePixelRatio/2,1)));
+                loadingPreview = false
             }
         }
     }

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -223,9 +223,12 @@ FocusScope {
             if (!webview.loading)
                 delayedCapture.restart()
         }
-        //onScrollPositionChanged: {
-        //    delayedCapture.restart()
-        //}
+        onScrollPositionChanged: {
+            delayedCapture.restart()
+        }
+        onWidthChanged: {
+            delayedCapture.restart()
+        }
     }
 
     onAboutToShow: {

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -197,7 +197,7 @@ FocusScope {
                 visible = false
 
                 PreviewManager.saveToDisk(result, url)
-            })
+            },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio));
         }
     }
 
@@ -208,21 +208,24 @@ FocusScope {
         id: delayedCapture
         interval: 500
         onTriggered: {
+            if (recentView.visible)
+                return
             if (webview && current && visible && !internal.hiding) {
                 webview.grabToImage(function(result) {
                     PreviewManager.saveToDisk(result, url)
-                })
+                },Qt.size(webview.width*Screen.devicePixelRatio,webview.height*Screen.devicePixelRatio))
             }
         }
     }
     Connections {
         target: incognito ? null : webview
-//        onLoadEvent: {
-//            if ((event.type == Oxide.LoadEvent.TypeSucceeded) ||
-//                (event.type == Oxide.LoadEvent.TypeFailed)) {
-//                delayedCapture.restart()
-//            }
-//        }
+        onLoadingChanged: {
+            if (!webview.loading)
+                delayedCapture.restart()
+        }
+        //onScrollPositionChanged: {
+        //    delayedCapture.restart()
+        //}
     }
 
     onAboutToShow: {

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -45,26 +45,17 @@ FocusScope {
     property bool incognito
     readonly property bool empty: !url.toString() && !initialUrl.toString() && !restoreState && !request
     property bool loadingPreview: false
-    readonly property size previewSize: Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),
-                                                webview.height*Math.max(Screen.devicePixelRatio/2,1))
+    readonly property size previewSize: Qt.size(webview.width*Screen.devicePixelRatio,
+                                                webview.height*Screen.devicePixelRatio)
+    readonly property size previewThumbnailSize: Qt.size(webview.width/2,
+                                                         webview.height/2)
+    //store reference to preview to avoid clearing by garbage collector
+    property var previewCache
     visible: false
 
     // Used as a workaround for https://launchpad.net/bugs/1502675 :
     // invoke this on a tab shortly before it is set current.
     signal aboutToShow()
-
-    Connections {
-        target: PreviewManager
-        onPreviewSaved: {
-            if (pageUrl !== url) return
-            if (preview == previewUrl) {
-                // Ensure that the preview URL actually changes,
-                // for the image to be reloaded
-                preview = ""
-            }
-            preview = previewUrl
-        }
-    }
 
     FaviconFetcher {
         id: faviconFetcher
@@ -193,14 +184,16 @@ FocusScope {
 
             internal.hiding = true
             webview.grabToImage(function(result) {
-                if (!internal.hiding) {
-                    return
-                }
-                internal.hiding = false
                 visible = false
-
-                PreviewManager.saveToDisk(result, url)
+                preview = result.url
+                previewCache = result
             },previewSize);
+
+            //save previews to disk for newtabpage and tab during grabbing
+            webview.grabToImage(function(result) {
+                internal.hiding = false
+                PreviewManager.saveToDisk(result, url)
+            },previewThumbnailSize);
         }
     }
 
@@ -211,9 +204,13 @@ FocusScope {
                 preview = ""
                 loadingPreview = true
                 webview.grabToImage(function(result) {
-                    PreviewManager.saveToDisk(result, url)
+                    preview = result.url
+                    previewCache = result
                 },previewSize);
-                loadingPreview = false
+
+                webview.grabToImage(function(result) {
+                    PreviewManager.saveToDisk(result, url)
+                },previewThumbnailSize);
             }
         }
     }

--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -45,6 +45,8 @@ FocusScope {
     property bool incognito
     readonly property bool empty: !url.toString() && !initialUrl.toString() && !restoreState && !request
     property bool loadingPreview: false
+    readonly property size previewSize: Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),
+                                                webview.height*Math.max(Screen.devicePixelRatio/2,1))
     visible: false
 
     // Used as a workaround for https://launchpad.net/bugs/1502675 :
@@ -198,7 +200,7 @@ FocusScope {
                 visible = false
 
                 PreviewManager.saveToDisk(result, url)
-            },Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),webview.height*Math.max(Screen.devicePixelRatio/2,1)));
+            },previewSize);
         }
     }
 
@@ -210,7 +212,7 @@ FocusScope {
                 loadingPreview = true
                 webview.grabToImage(function(result) {
                     PreviewManager.saveToDisk(result, url)
-                },Qt.size(webview.width*Math.max(Screen.devicePixelRatio/2,1),webview.height*Math.max(Screen.devicePixelRatio/2,1)));
+                },previewSize);
                 loadingPreview = false
             }
         }

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -70,19 +70,6 @@ QQC2.SwipeDelegate {
                 left: parent.left
                 right: parent.right
             }
-            onVisibleChanged: {
-                if (visible && tab.current)
-                    tabShowing.start()
-            }
-
-            PropertyAnimation {
-                id: tabShowing
-                target: parent
-                property: "opacity"
-                from: 0
-                to: 1
-                duration: UbuntuAnimation.FastDuration
-            }
 
 
 
@@ -143,6 +130,11 @@ QQC2.SwipeDelegate {
                 source: tabPreview.tab ? tabPreview.tab.preview : ""
                 asynchronous: true
                 cache: false
+                onStatusChanged: {
+                    if (status != Image.Loading) {
+                        tab.loadingPreview = false
+                    }
+                }
             }
         }
     }

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -44,11 +44,6 @@ QQC2.SwipeDelegate {
     swipe.onCompleted: closed()
     onClicked: tabPreview.selected()
 
-    // The first preview in the tabs list is a special case.
-    // Since it’s the current tab, instead of displaying a
-    // capture, the webview below it is displayed.
-    property bool showContent: true
-
     signal selected()
     signal closed()
 
@@ -98,11 +93,10 @@ QQC2.SwipeDelegate {
             Rectangle {
                 anchors.fill: parent
                 color: theme.palette.normal.foreground
-                visible: showContent
             }
 
             Image {
-                visible: showContent && !previewContainer.visible
+                visible: !previewContainer.visible
                 source: "assets/tab-artwork.png"
                 asynchronous: true
                 fillMode: Image.PreserveAspectFit
@@ -128,7 +122,7 @@ QQC2.SwipeDelegate {
             }
 
             Label {
-                visible: showContent && !previewContainer.visible
+                visible: !previewContainer.visible
                 text: i18n.tr("Tap to view")
                 anchors {
                     centerIn: parent
@@ -138,7 +132,7 @@ QQC2.SwipeDelegate {
 
             Image {
                 id: previewContainer
-                visible: showContent && source.toString() && (status == Image.Ready)
+                visible: source.toString() && (status == Image.Ready)
                 anchors {
                     left: parent.left
                     top: parent.top

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -75,6 +75,23 @@ QQC2.SwipeDelegate {
                 left: parent.left
                 right: parent.right
             }
+            onVisibleChanged: {
+                if (visible && tab.current)
+                    tabShowing.start()
+            }
+
+            PropertyAnimation {
+                id: tabShowing
+                target: parent
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: UbuntuAnimation.FastDuration
+            }
+
+
+
+            visible: !tab.loadingPreview
             height: parent.height
             clip: true
 
@@ -132,12 +149,6 @@ QQC2.SwipeDelegate {
                 source: tabPreview.tab ? tabPreview.tab.preview : ""
                 asynchronous: true
                 cache: false
-                onStatusChanged: {
-                    if (status == Image.Error) {
-                        // The cached preview doesn’t exist any longer
-                        tabPreview.tab.preview = ""
-                    }
-                }
             }
         }
     }

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -107,10 +107,10 @@ Item {
             anchors {
                 left: parent.left
                 top: parent.top
+                right: parent.right
                 topMargin: -chrome.height
             }
-            height: sourceSize.height
-            fillMode: Image.Pad
+            fillMode: Image.PreserveAspectFit
             source: tabPreview.tab ? tabPreview.tab.preview : ""
             asynchronous: true
             cache: false

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -112,20 +112,18 @@ QQC2.SwipeDelegate {
                 visible: !previewContainer.visible
                 text: i18n.tr("Tap to view")
                 anchors {
-                    centerIn: parent
-                    verticalCenterOffset: units.gu(-2)
+                    top: parent.top
+                    topMargin: units.gu(12)
+                    horizontalCenter: parent.horizontalCenter
                 }
             }
 
             Image {
                 id: previewContainer
                 visible: source.toString() && (status == Image.Ready)
-                anchors {
-                    left: parent.left
-                    top: parent.top
-                    topMargin: units.dp(1)
-                    right: parent.right
-                }
+                anchors.fill: parent
+                anchors.topMargin: units.dp(1)
+                verticalAlignment: Image.AlignTop
                 fillMode: Image.PreserveAspectFit
                 source: tabPreview.tab ? tabPreview.tab.preview : ""
                 asynchronous: true

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -18,8 +18,9 @@
 
 import QtQuick 2.4
 import Ubuntu.Components 1.3
+import QtQuick.Controls 2.2 as QQC2
 
-Item {
+QQC2.SwipeDelegate {
     id: tabPreview
 
     property alias title: chrome.title
@@ -27,6 +28,21 @@ Item {
     property alias incognito: chrome.incognito
     property var tab
     readonly property url url: tab ? tab.url : ""
+
+    background: Rectangle {
+        anchors.fill: parent
+        color: "transparent"
+    }
+    padding: 0
+    swipe.enabled: true
+    swipe.behind: Rectangle {
+        width: tabPreview.width
+        height: tabPreview.height
+        color: "transparent"
+    }
+
+    swipe.onCompleted: closed()
+    onClicked: tabPreview.selected()
 
     // The first preview in the tabs list is a special case.
     // Since it’s the current tab, instead of displaying a
@@ -36,113 +52,90 @@ Item {
     signal selected()
     signal closed()
 
-    TabChrome {
-        id: chrome
+    contentItem: Item {
 
-        anchors {
-            top: parent.top
-            left: parent.left
-            right: parent.right
-        }
-        tabWidth: units.gu(26)
+        TabChrome {
+            id: chrome
 
-        onSelected: tabPreview.selected()
-        onClosed: tabPreview.closed()
-    }
-
-    Item {
-        anchors {
-            top: chrome.bottom
-            topMargin: units.dp(-1)
-            left: parent.left
-            right: parent.right
-        }
-        height: parent.height
-        clip: true
-
-        Rectangle {
-            anchors.fill: parent
-            color: theme.palette.normal.foreground
-            visible: showContent
-        }
-
-        Image {
-            visible: showContent && !previewContainer.visible
-            source: "assets/tab-artwork.png"
-            asynchronous: true
-            fillMode: Image.PreserveAspectFit
-            width: parent.width / 5
-            height: width
-            anchors {
-                right: parent.right
-                rightMargin: -width / 5
-                bottom: parent.bottom
-                bottomMargin: -height / 10
-            }
-        }
-
-        Rectangle {
             anchors {
                 top: parent.top
                 left: parent.left
                 right: parent.right
             }
-            height: units.dp(1)
+            tabWidth: units.gu(26)
 
-            color: theme.palette.normal.base
+            onSelected: tabPreview.selected()
+            onClosed: tabPreview.closed()
         }
 
-        Label {
-            visible: showContent && !previewContainer.visible
-            text: i18n.tr("Tap to view")
+        Item {
             anchors {
-                centerIn: parent
-                verticalCenterOffset: units.gu(-2)
-            }
-        }
-
-        Image {
-            id: previewContainer
-            visible: showContent && source.toString() && (status == Image.Ready)
-            anchors {
+                top: chrome.bottom
+                topMargin: units.dp(-1)
                 left: parent.left
-                top: parent.top
                 right: parent.right
-                topMargin: -chrome.height
             }
-            fillMode: Image.PreserveAspectFit
-            source: tabPreview.tab ? tabPreview.tab.preview : ""
-            asynchronous: true
-            cache: false
-            onStatusChanged: {
-                if (status == Image.Error) {
-                    // The cached preview doesn’t exist any longer
-                    tabPreview.tab.preview = ""
+            height: parent.height
+            clip: true
+
+            Rectangle {
+                anchors.fill: parent
+                color: theme.palette.normal.foreground
+                visible: showContent
+            }
+
+            Image {
+                visible: showContent && !previewContainer.visible
+                source: "assets/tab-artwork.png"
+                asynchronous: true
+                fillMode: Image.PreserveAspectFit
+                width: parent.width / 5
+                height: width
+                anchors {
+                    right: parent.right
+                    rightMargin: -width / 5
+                    bottom: parent.bottom
+                    bottomMargin: -height / 10
                 }
             }
-        }
 
-        MouseArea {
-            objectName: "selectArea"
-            anchors.fill: parent
-            acceptedButtons: Qt.AllButtons
+            Rectangle {
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    right: parent.right
+                }
+                height: units.dp(1)
 
-            // 'clicked' events are emitted even if the cursor has been dragged
-            // (http://doc.qt.io/qt-5/qml-qtquick-mousearea.html#clicked-signal),
-            // but we don’t want a drag gesture to select the tab (when e.g. the
-            // user has reached the top/bottom of the tabs view and starts another
-            // gesture to drag further beyond the boundaries of the view).
-            property point pos
-            onPressed: {
-                if (mouse.button == Qt.LeftButton) {
-                    pos = Qt.point(mouse.x, mouse.y)
+                color: theme.palette.normal.base
+            }
+
+            Label {
+                visible: showContent && !previewContainer.visible
+                text: i18n.tr("Tap to view")
+                anchors {
+                    centerIn: parent
+                    verticalCenterOffset: units.gu(-2)
                 }
             }
-            onReleased: {
-                if (mouse.button == Qt.LeftButton) {
-                    var d = Math.sqrt(Math.pow(mouse.x - pos.x, 2) + Math.pow(mouse.y - pos.y, 2))
-                    if (d < units.gu(1)) {
-                        tabPreview.selected()
+
+            Image {
+                id: previewContainer
+                visible: showContent && source.toString() && (status == Image.Ready)
+                anchors {
+                    left: parent.left
+                    top: parent.top
+                    topMargin: units.dp(1)
+                    right: parent.right
+                }
+                fillMode: Image.PreserveAspectFit
+                source: tabPreview.tab ? tabPreview.tab.preview : ""
+                asynchronous: true
+                cache: false
+                onStatusChanged: {
+                    if (status == Image.Error) {
+                        // The cached preview doesn’t exist any longer
+                        tabPreview.tab.preview = ""
                     }
                 }
             }

--- a/src/app/webbrowser/TabPreview.qml
+++ b/src/app/webbrowser/TabPreview.qml
@@ -30,7 +30,6 @@ QQC2.SwipeDelegate {
     readonly property url url: tab ? tab.url : ""
 
     background: Rectangle {
-        anchors.fill: parent
         color: "transparent"
     }
     padding: 0

--- a/src/app/webbrowser/TabsList.qml
+++ b/src/app/webbrowser/TabsList.qml
@@ -69,7 +69,8 @@ Item {
 
                 width: flickable.contentWidth
 
-                height: (index == (repeater.model.count - 1)) || index == 0 ? flickable.height : delegateHeight
+                height: (index == (repeater.model.count - 1)) || index == 0 || (animating && index == selectedAnimation.index)
+                        ? flickable.height : delegateHeight
                 Behavior on height {
                     UbuntuNumberAnimation {
                         duration: UbuntuAnimation.BriskDuration
@@ -126,7 +127,7 @@ Item {
             property int index: 0
             target: flickable
             property: "contentY"
-            to: index * delegateHeight - chromeHeight + invisibleTabChrome.height
+            to: index * delegateHeight
             duration: UbuntuAnimation.FastDuration
             onStopped: {
                 // Delay switching the tab until after the animation has completed.

--- a/src/app/webbrowser/TabsList.qml
+++ b/src/app/webbrowser/TabsList.qml
@@ -44,8 +44,19 @@ Item {
     }
 
     Rectangle {
-        anchors.fill: parent
+        id: backrect
+        width: parent.width
+        height: dealayBackground.running ? invisibleTabChrome.height : parent.height
         color: theme.palette.normal.base
+    }
+    onVisibleChanged: {
+        if (visible)
+            dealayBackground.start()
+    }
+
+    Timer {
+        id: dealayBackground
+        interval: 300
     }
 
     Flickable {

--- a/src/app/webbrowser/TabsList.qml
+++ b/src/app/webbrowser/TabsList.qml
@@ -44,13 +44,8 @@ Item {
     }
 
     Rectangle {
-        anchors {
-            top: parent.top
-            left: parent.left
-            right: parent.right
-        }
-        height: invisibleTabChrome.height
-        color: theme.palette.normal.backgroundText
+        anchors.fill: parent
+        color: theme.palette.normal.base
     }
 
     Flickable {
@@ -74,7 +69,7 @@ Item {
 
                 width: flickable.contentWidth
 
-                height: (index == (repeater.model.count - 1)) ? flickable.height : delegateHeight
+                height: (index == (repeater.model.count - 1)) || index == 0 ? flickable.height : delegateHeight
                 Behavior on height {
                     UbuntuNumberAnimation {
                         duration: UbuntuAnimation.BriskDuration
@@ -108,8 +103,7 @@ Item {
                     icon: delegate.icon
                     incognito: tabslist.incognito
                     tab: model.tab
-                    showContent: ((index > 0) && (delegate.y > flickable.contentY)) ||
-                                 !(tab && tab.webview && tab.webview.visible)
+                    showContent: true
 
                   /*  Binding {
                         // Change the height of the location bar controller

--- a/src/app/webbrowser/TabsList.qml
+++ b/src/app/webbrowser/TabsList.qml
@@ -80,13 +80,7 @@ Item {
 
                 width: flickable.contentWidth
 
-                height: (index == (repeater.model.count - 1)) || index == 0 || (animating && index == selectedAnimation.index)
-                        ? flickable.height : delegateHeight
-                Behavior on height {
-                    UbuntuNumberAnimation {
-                        duration: UbuntuAnimation.BriskDuration
-                    }
-                }
+                height: flickable.height
 
                 y: Math.max(flickable.contentY, index * delegateHeight)
                 Behavior on y {

--- a/src/app/webbrowser/TabsList.qml
+++ b/src/app/webbrowser/TabsList.qml
@@ -115,7 +115,6 @@ Item {
                     icon: delegate.icon
                     incognito: tabslist.incognito
                     tab: model.tab
-                    showContent: true
 
                   /*  Binding {
                         // Change the height of the location bar controller


### PR DESCRIPTION
This should fix https://github.com/ubports/morph-browser/issues/119 and fix https://github.com/ubports/morph-browser/issues/325