### PR TITLE
Set Desktop Mode from Main Menu

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -818,6 +818,14 @@ Common.BrowserView {
                 iconName: "zoom-in"
                 enabled: currentWebview && (currentWebview.url.toString() !== "")
                 onTriggered: currentWebview.showZoomMenu()
+            },
+            Action {
+                objectName: "desktopmode"
+                text: i18n.tr("Set Desktop mode")
+                iconName: "computer"
+                checkable: true
+                checked: settings.setDesktopMode
+                onToggled: settings.setDesktopMode = checked
             }
 
         ]


### PR DESCRIPTION
This small addition shows the _Set Desktop Mode_ checkable action in the Main / Hamburger Menu, so that users can easily switch between the desktop and mobile versions of the web page. Fixes #324.