### PR TITLE
Focus the address bar on a new/blank tab even without physical keyboard

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -1299,7 +1299,7 @@ Common.BrowserView {
                 tab.load()
             }
             if (!url.toString()) {
-                maybeFocusAddressBar()
+                focusAddressBar()
             }
         }
 
@@ -1414,7 +1414,7 @@ Common.BrowserView {
                     recentView.focus = true
                 } else if (tab) {
                     if (tab.empty) {
-                        maybeFocusAddressBar()
+                        focusAddressBar()
                     } else {
                         tabContainer.forceActiveFocus()
                         tab.load();
@@ -1433,18 +1433,10 @@ Common.BrowserView {
             var currentTab = tabsModel.currentTab;
             if (currentTab) {
                 if (currentTab.empty) {
-                    internal.maybeFocusAddressBar()
+                    internal.focusAddressBar()
                 } else {
                     contentsContainer.focus = true;
                 }
-            }
-        }
-
-        function maybeFocusAddressBar() {
-            if (keyboardModel.count > 0) {
-                focusAddressBar()
-            } else {
-                contentsContainer.forceActiveFocus()
             }
         }
 


### PR DESCRIPTION
The current implementation is that the address bar is only focused when a physical keyboard is present. With this change, it will always be focused regardless.

I vote for this change because it's a lot more frequent that a user types a new URL/search text when opening a new tab than opening from item in the blank tab (top sites, bookmark, etc.). 

The trade-off is also equal for both cases.
Don't focus
 - Tap on the bookmark/top site
 - Tap on the address bar at the top and start typing

Focus
 - Close the keyboard and tap the bookmark/top site
 - Start typing