### PR TITLE
Increased the height of tabs

### DIFF
--- a/src/app/webbrowser/Chrome.qml
+++ b/src/app/webbrowser/Chrome.qml
@@ -82,7 +82,7 @@ ChromeBase {
                 top: parent.top
             }
             asynchronous: true
-            height: active ? units.gu(3) : 0
+            height: active ? units.gu(4) : 0
 
             Component.onCompleted: {
                 setSource(

--- a/src/app/webbrowser/TabChrome.qml
+++ b/src/app/webbrowser/TabChrome.qml
@@ -29,7 +29,7 @@ Item {
     signal selected()
     signal closed()
 
-    height: units.gu(4)
+    height: units.gu(5)
 
     Image {
         anchors {

--- a/src/app/webbrowser/TabItem.qml
+++ b/src/app/webbrowser/TabItem.qml
@@ -82,7 +82,7 @@ Item {
                 anchors.fill: parent
                 verticalAlignment: Text.AlignVCenter
                 clip: true
-                fontSize: "small"
+                textSize: Label.Medium
                 color: tabItem.fgColor
             }
 


### PR DESCRIPTION
Tab height in wide screen mode is too small and looks bad in desktop mode and even worse on tablets since they are hard to hit.
Tab height in narrow screen mode was also increased so that they are more visible to users and easy to spot when trying to switch to a tab.

Fixes #221 