### PR TITLE
Remove dependency on old unity-webapps-qml.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,6 @@ Depends: ${misc:Depends},
          qtdeclarative5-ubuntu-content1,
          qtdeclarative5-ubuntu-ui-toolkit-plugin (>= 1.3) | qtdeclarative5-ubuntu-ui-toolkit-plugin-gles (>= 1.3),
          qtdeclarative5-unity-action-plugin,
-         unity-webapps-qml,
          morph-browser (= ${binary:Version}),
 Conflicts: ubuntu-html5-container, webapp-container
 Replaces: ubuntu-html5-container, webapp-container

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -23,7 +23,6 @@ import webbrowsercommon.private 0.1
 import Morph.Web 0.1
 import Ubuntu.Components 1.3
 import Ubuntu.Unity.Action 1.1 as UnityActions
-import Ubuntu.UnityWebApps 0.1 as UnityWebApps
 import "../actions" as Actions
 import ".." as Common
 import "ColorUtils.js" as ColorUtils
@@ -241,7 +240,7 @@ Common.BrowserView {
              * the fact that a webapp 'name' can come from a webapp-properties.json file w/o
              * being explictly defined here.
              */
-            webappName: webapp.webappName === "" ? unityWebapps.name : webapp.webappName
+            webappName: webapp.webappName
 
             Loader {
                 anchors {
@@ -459,24 +458,6 @@ Common.BrowserView {
         //    defaultMode: webapp.hasTouchScreen
         //                     ? Oxide.LocationBarController.ModeAuto
         //                     : Oxide.LocationBarController.ModeShown
-        }
-    }
-
-    UnityWebApps.UnityWebApps {
-        id: unityWebapps
-        name: webappName
-        bindee: containerWebView.currentWebview
-        actionsContext: actionManager.globalContext
-        model: UnityWebApps.UnityWebappsAppModel { searchPath: webappModelSearchPath }
-        injectExtraUbuntuApis: runningLocalApplication
-        injectExtraContentShareCapabilities: !runningLocalApplication
-
-        Component.onCompleted: {
-            // Delay bind the property to add a bit of backward compatibility with
-            // other unity-webapps-qml modules
-            if (unityWebapps.embeddedUiComponentParent !== undefined) {
-                unityWebapps.embeddedUiComponentParent = webapp
-            }
         }
     }
 

--- a/src/app/webcontainer/WebViewImplOxide.qml
+++ b/src/app/webcontainer/WebViewImplOxide.qml
@@ -20,7 +20,6 @@ import QtQuick 2.4
 import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
-import Ubuntu.UnityWebApps 0.1 as UnityWebApps
 import QtWebEngine 1.7
 import Morph.Web 0.1
 import webbrowsercommon.private 0.1
@@ -181,17 +180,7 @@ WebappWebview {
     }
 
     function shouldAllowNavigationTo(url) {
-        // The list of url patterns defined by the webapp takes precedence over command line
-        if (isRunningAsANamedWebapp()) {
-            if (unityWebapps.model.exists(unityWebapps.name) &&
-                unityWebapps.model.doesUrlMatchesWebapp(unityWebapps.name, url)) {
-                return true;
-            }
-        }
-
-        // We still take the possible additional patterns specified in the command line
-        // (the in the case of finer grained ones specifically for the container and not
-        // as an 'install source' for the webapp).
+        // Check if URL requested matches against provided patterns
         if (haveValidUrlPatterns()) {
             for (var i = 0; i < webappUrlPatterns.length; ++i) {
                 var pattern = webappUrlPatterns[i]
@@ -406,20 +395,6 @@ WebappWebview {
                 console.debug('ignored request of current page to %1.'.arg(url));
             }
       }
-    }
-
-    // Small shim needed when running as a webapp to wire-up connections
-    // with the webview (message received, etc…).
-    // This is being called (and expected) internally by the webapps
-    // component as a way to bind to a webview lookalike without
-    // reaching out directly to its internals (see it as an interface).
-    function getUnityWebappsProxies() {
-        var eventHandlers = {
-            onAppRaised: function () {
-                window.raise();
-            }
-        };
-        return UnityWebAppsUtils.makeProxiesForWebViewBindee(webview, eventHandlers)
     }
 
     function handlePageMetadata(metadata) {

--- a/src/app/webcontainer/WebappContainerWebview.qml
+++ b/src/app/webcontainer/WebappContainerWebview.qml
@@ -20,7 +20,6 @@ import QtQuick 2.4
 import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 import Ubuntu.Unity.Action 1.1 as UnityActions
-import Ubuntu.UnityWebApps 0.1 as UnityWebApps
 import "../actions" as Actions
 import "../UrlUtils.js" as UrlUtils
 import ".."

--- a/src/app/webcontainer/webapp-container.qml
+++ b/src/app/webcontainer/webapp-container.qml
@@ -19,7 +19,6 @@
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import Qt.labs.settings 1.0
-import Ubuntu.UnityWebApps 0.1 as UnityWebApps
 import QtWebEngine 1.10
 import Morph.Web 0.1
 import webcontainer.private 0.1
@@ -157,20 +156,6 @@ BrowserWindow {
         return ""
     }
 
-    UnityWebApps.UnityWebappsAppModel {
-        id: webappModel
-        searchPath: root.webappModelSearchPath
-
-        onModelContentChanged: {
-            var name = getWebappName()
-            if (name && root.url.length === 0) {
-                var idx = webappModel.getWebappIndex(name)
-                root.url = webappModel.data(
-                            idx, UnityWebApps.UnityWebappsAppModel.Homepage)
-            }
-        }
-    }
-
     // Because of https://launchpad.net/bugs/1398046, it's important that this
     // is the first child
     Loader {
@@ -209,8 +194,7 @@ BrowserWindow {
             var scripts = [];
 
             // app specific user scripts
-            var idx = webappModel.getWebappIndex(getWebappName());
-            var customScripts = webappModel.data(idx, UnityWebApps.UnityWebappsAppModel.Scripts);
+            var customScripts = []
 
             if ((typeof customScripts === "undefined") || (customScripts.length === 0))
             {
@@ -316,7 +300,6 @@ BrowserWindow {
 
     function startBrowsing() {
         console.log("Start browsing")
-        // This will activate the UnityWebApp element used in WebApp.qml
         webappViewLoader.item.webappName = root.webappName
 
         // As we use StateSaver to restore the URL, we need to check first if


### PR DESCRIPTION
As unity-webapps-qml seems to not really be used any more, and it also
depends on Oxide or QtWebKit which are both deprecated, just remove the
usage and dependency on it.