### PR TITLE
Add clickable config for Qt 5.12 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Simply use [clickable](http://clickable.bhdouglass.com/en/latest/) command line
 
 	$ clickable
 
+For a Qt 5.12 based build run
+
+	$ clickable -c clickable-qt-5.12.json
+
 = Running =
 
 webbrowser-app can be run from the development branch without the need to

--- a/clickable-qt-5.12.json
+++ b/clickable-qt-5.12.json
@@ -1,9 +1,13 @@
 {
-  "clickable_minimum_required": "6.12.2",
+  "clickable_minimum_required": "6.20.1",
   "builder": "cmake",
   "kill": "morph-browser",
   "build_args": "-DCLICK_MODE=ON",
+  "dependencies_host": [
+    "qdoc-qt5"
+  ],
   "dependencies_target": [
     "qtwebengine5-dev"
-  ]
+  ],
+  "qt_version": "5.12"
 }


### PR DESCRIPTION
This MR:
- adds the clickable config `clickable-qt-5.12.json` that allows building and packaging Morph with Qt 5.12
- fixes the usage of the deprecated `template` field in the clickable.json
- adds the `clickable_minimum_required` field in the clickable.json
- adds a note to the `README.md`

Before merging:
- [ ] Wait for [Clickable Qt 5.12 support](https://gitlab.com/clickable/clickable/-/merge_requests/336) to be released
- [ ] Adjust `clickable_minimum_required` field in `clickable-qt-5.12.json` accordingly