### PR TITLE
Fixed #426

### DIFF
--- a/src/app/webbrowser/TabItem.qml
+++ b/src/app/webbrowser/TabItem.qml
@@ -115,15 +115,13 @@ Item {
             anchors.bottom: parent.bottom
             anchors.right: parent.right
             acceptedButtons: Qt.AllButtons
-            onPressed: {
+
+            onClicked: {
                 if (mouse.button === Qt.LeftButton) {
                     tabItem.selected()
                 } else if (mouse.button === Qt.RightButton) {
                     tabItem.contextMenu()
-                }
-            }
-            onClicked: {
-                if ((mouse.buttons === 0) && (mouse.button === Qt.MiddleButton)) {
+                } else if ((mouse.buttons === 0) && (mouse.button === Qt.MiddleButton)) {
                     tabItem.closed()
                 }
             }


### PR DESCRIPTION
Removed `press` event handler in `TabItem` and moved it in the `click` handler.

This avoids selecting a tab when starting a swipe for the tab chrome.