### PR TITLE
Fix ubports/ubuntu-touch#1344 for rotated contents on external displays

### DIFF
--- a/src/app/BrowserView.qml
+++ b/src/app/BrowserView.qml
@@ -52,6 +52,8 @@ FocusScope {
     OrientationHelper {
         id: contentsItem
 
+        automaticOrientation: false
+
         KeyboardRectangle {
             id: _osk
         }

--- a/src/app/BrowserWindow.qml
+++ b/src/app/BrowserWindow.qml
@@ -29,7 +29,6 @@ Window {
     property var currentWebview: null
     property bool hasTouchScreen: false
 
-    contentOrientation: Screen.orientation
 
     minimumWidth: units.gu(40)
     minimumHeight: units.gu(20)


### PR DESCRIPTION
Set automaticOrientation to false to fix ubports/ubuntu-touch#1344