### PR TITLE
Bottom edge tweaks

### DIFF
--- a/src/app/webbrowser/BottomEdgeHandle.qml
+++ b/src/app/webbrowser/BottomEdgeHandle.qml
@@ -22,7 +22,9 @@ import Ubuntu.Components 1.3
 SwipeArea {
     direction: SwipeArea.Upwards
 
-    readonly property real dragFraction: dragging ? Math.min(1.0, Math.max(0.0, distance / parent.height)) : 0.0
+    readonly property real dragFraction: Math.min(1.0, Math.max(0.0, distance / parent.height))
     readonly property var thresholds: [0.05, 0.18, 0.36, 0.54, 1.0]
     readonly property int stage: thresholds.map(function(t) { return dragFraction <= t }).indexOf(true)
+
+    immediateRecognition: true
 }

--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -560,7 +560,6 @@ Common.BrowserView {
             if (visible) {
 
                 currentWebview.hideContextMenu();
-                chrome.state = "hidden";
             }
             else {
                 chrome.state = "shown";
@@ -569,6 +568,12 @@ Common.BrowserView {
 
         states: State {
             name: "shown"
+        }
+        
+        onStateChanged: {
+            if (state === "shown") {
+                chrome.state = "hidden";
+            }
         }
 
         function closeAndSwitchToTab(index) {
@@ -584,16 +589,20 @@ Common.BrowserView {
             model: tabsModel
             readonly property real delegateMinHeight: units.gu(20)
             delegateHeight: {
-                if (recentView.state == "shown") {
-                    return Math.max(height / 3, delegateMinHeight)
-                } else if (bottomEdgeHandle.stage == 0) {
-                    return height
-                } else if (bottomEdgeHandle.stage == 1) {
-                    return (1 - 1.8 * bottomEdgeHandle.dragFraction) * height
-                } else if (bottomEdgeHandle.stage >= 2) {
-                    return Math.max(height / 3, delegateMinHeight)
+                if (recentView.visible) {
+                    if (recentView.state == "shown") {
+                        return Math.max(height / 3, delegateMinHeight)
+                    } else if (bottomEdgeHandle.stage == 0) {
+                        return height
+                    } else if (bottomEdgeHandle.stage == 1) {
+                        return (1 - 1.8 * bottomEdgeHandle.dragFraction) * height
+                    } else if (bottomEdgeHandle.stage >= 2) {
+                        return Math.max(height / 3, delegateMinHeight)
+                    } else {
+                        return delegateMinHeight
+                    }
                 } else {
-                    return delegateMinHeight
+                    return height
                 }
             }
             chromeHeight: chrome.height

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -221,24 +221,6 @@ FocusScope {
             }
 
             ChromeButton {
-                id: closeButton
-                objectName: "closeButton"
-
-                iconName: "close"
-                iconSize: 0.3 * height
-                iconColor: root.iconColor
-
-                height: root.height
-                width: height * 0.8
-
-                anchors.verticalCenter: parent.verticalCenter
-
-                visible: tabListMode
-
-                onTriggered: closeTabRequested()
-            }
-
-            ChromeButton {
                 id: drawerButton
                 objectName: "drawerButton"
 


### PR DESCRIPTION
 - Hide navigationbar only when the recent view is fully shown to reduce screen activities/animations when switching to the last tab (short swipe)
 - Enabled  `immediateRecognition` in the bottom edge handler to avoid scrolling webviews when swiping from the bottom
 - Removed the close button from the navigation bar
 - Fixed animation when doing a short swipe for switching to the last tab. Previous animation restarts the position from the bottom of the screen instead of continuing from the swipe/drag. It also previously does not reach the top and jumps at some point.