### PR TITLE
Open links next to current tab

### DIFF
--- a/src/app/webbrowser/Browser.qml
+++ b/src/app/webbrowser/Browser.qml
@@ -133,6 +133,10 @@ Common.BrowserView {
     signal shareLinkRequested(url linkUrl, string title)
     signal shareTextRequested(string text)
 
+    onOpenLinkInNewTabRequested: {
+        internal.openUrlInNewTab(url, !background, true, tabsModel.selectedIndex + 1)
+    }
+
     onShareLinkRequested: {
 
         internal.shareLink(linkUrl, title);

--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -235,17 +235,6 @@ QtObject {
                     window.requestActivate()
                 }
 
-                onOpenLinkInNewTabRequested: {
-
-                    window.addTab(url);
-
-                    if (! background)
-                    {
-                        window.tabsModel.currentIndex = window.tabsModel.count - 1
-                        window.tabsModel.currentTab.load()
-                    }
-                }
-
                 // Not handled as a window-level shortcut as it would take
                 // precedence over key events in web content.
                 Keys.onEscapePressed: {


### PR DESCRIPTION
 - Fixed #326
 - Opening links to a new tab now opens next to the current tab instead of at the end of tabs.
 - This impacts opening link to new tab, new background tab, view source, view image to tab, and open video to new tab.