### PR TITLE
cover up scaling cracks

### DIFF
--- a/src/app/webbrowser/morph-browser.qml
+++ b/src/app/webbrowser/morph-browser.qml
@@ -96,6 +96,8 @@ QtObject {
         BrowserWindow {
             id: window
 
+            color: "#111111"
+
             property alias incognito: browser.incognito
             readonly property alias model: browser.tabsModel
             readonly property var tabsModel: browser.tabsModel


### PR DESCRIPTION
make sure the window background underneath everything blends in with indicator bar.
"painting" the cracks seen when qt scaling rounds poorly on certain gu sizes

This happens on the volla phone default scale, and other devices or on different scaling.