### PR TITLE
Adds navigation history in the back/forward button

### DIFF
--- a/src/app/ChromeButton.qml
+++ b/src/app/ChromeButton.qml
@@ -23,11 +23,23 @@ AbstractButton {
     property real iconSize: width
     property alias iconName: icon.name
     property alias iconColor: icon.color
+    property bool enableContextMenu: false
+    property var contextMenu: null
+    property bool pressedState: false
+
+    signal showContextMenu
+
+    onShowContextMenu: pressedState = true
+
+    Connections {
+        target: contextMenu
+        onVisibleChanged: if (!target.visible) pressedState = false
+    }
 
     Rectangle {
         anchors.fill: parent
         color: theme.palette.selected.background
-        visible: parent.pressed
+        visible: parent.pressed || pressedState
     }
 
     Icon {
@@ -43,4 +55,12 @@ AbstractButton {
     Behavior on width {
         UbuntuNumberAnimation {}
     }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+        onClicked: if (enableContextMenu) showContextMenu()
+    }
+
+    onPressAndHold: if (enableContextMenu) showContextMenu()
 }

--- a/src/app/NavHistoryDialog.qml
+++ b/src/app/NavHistoryDialog.qml
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015-2016 Canonical Ltd.
+ *
+ * This file is part of morph-browser.
+ *
+ * morph-browser is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * morph-browser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import Ubuntu.Components 1.3
+import Ubuntu.Components.Popups 1.3
+
+Popover {
+    id: navHistoryDialog
+
+    property alias model: historyListView.model
+
+    property bool incognito: false
+    property real availableHeight
+    property real availableWidth
+    property real maximumWidth: units.gu(70)
+    property real preferredWidth: availableWidth - units.gu(4)
+
+    signal navigate(int offset)
+
+    contentWidth: Math.min(preferredWidth, maximumWidth)
+
+    grabDismissAreaEvents: true
+
+    onVisibleChanged: if (visible) historyListView.forceActiveFocus()
+
+    Rectangle {
+        id: bgRec
+        
+        color: theme.palette.normal.foreground
+        anchors.fill: parent
+        z: -1
+    }
+
+    ScrollView {
+        property real maximumHeight: navHistoryDialog.availableHeight
+        property real preferredHeight:  historyListView.contentItem.height
+
+        anchors {
+            left: parent.left
+            top: parent.top
+            right: parent.right
+        }
+        height: Math.min(preferredHeight, maximumHeight)
+
+        UbuntuListView {
+            id: historyListView
+
+            anchors.fill: parent
+            currentIndex: -1
+            clip: true
+
+            delegate: ListItem {
+                height: layout.height + (divider.visible ? divider.height : 0)
+
+                onClicked: navigate(model.offset)
+
+                MouseArea {
+                    id: hover
+                    
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    anchors.fill: parent
+                }
+
+                Rectangle {
+                    id: hoverBg
+
+                    z: -1
+                    anchors.fill: parent
+                    opacity: 0.2
+                    visible: hover.containsMouse
+                    color: theme.palette.normal.focus
+                }
+                ListItemLayout {
+                    id: layout
+
+                    title.text: model.title
+                    title.color: theme.palette.normal.foregroundText
+
+                    Favicon {
+                        id: favicon
+                        
+                        source: model.icon
+                        SlotsLayout.position: SlotsLayout.Leading;
+                        shouldCache: !navHistoryDialog.incognito
+
+                        height: width
+                        width: units.gu(2)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/NavHistoryPopup.qml
+++ b/src/app/NavHistoryPopup.qml
@@ -42,7 +42,7 @@ QQC2.Popup {
     bottomPadding: 0
 
     function show(caller){
-        var mapped = caller.mapToItem(root, 0, 0)
+        var mapped = caller.mapToItem(parent, 0, 0)
         x = Qt.binding(function(){
                 if (width == maximumWidth) {
                     return mapped.x

--- a/src/app/NavHistoryPopup.qml
+++ b/src/app/NavHistoryPopup.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Canonical Ltd.
+ * Copyright 2021 UBports Foundation
  *
  * This file is part of morph-browser.
  *

--- a/src/app/webbrowser/NavigationBar.qml
+++ b/src/app/webbrowser/NavigationBar.qml
@@ -18,7 +18,6 @@
 
 import QtQuick 2.4
 import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
 import QtWebEngine 1.7
 import ".."
 
@@ -55,16 +54,18 @@ FocusScope {
     }
 
     function showNavHistory(model, caller) {
-        if (caller === undefined) caller = root
-        var properties = {"model": model
-                ,"incognito": incognito
-                ,"availableHeight": availableHeight
-                ,"availableWidth": width
-            }
+        navHistPopup.model = model
+        navHistPopup.show(caller)
+    }
 
-        var navHistory = PopupUtils.open(Qt.resolvedUrl("../NavHistoryDialog.qml"),
-                                                       caller, properties)
-        return navHistory
+    NavHistoryPopup {
+        id: navHistPopup
+        
+        availHeight: root.availableHeight
+        availWidth: root.width
+        onNavigate: {
+            internal.webview.goBackOrForward(offset)
+        }
     }
 
     FocusScope {
@@ -87,6 +88,7 @@ FocusScope {
             width: height * 0.8
 
             enableContextMenu: true
+            contextMenu: navHistPopup
 
             anchors {
                 left: parent.left
@@ -105,15 +107,7 @@ FocusScope {
                 }
             }
 
-            onShowContextMenu: contextMenu = showNavHistory(internal.webview.navigationHistory.backItems, backButton)
-            
-            Connections {
-                target: backButton.contextMenu
-                onNavigate: {
-                    internal.webview.goBackOrForward(offset)
-                    PopupUtils.close(target)
-                }
-            }
+            onShowContextMenu: showNavHistory(internal.webview.navigationHistory.backItems, backButton)
         }
 
         Connections {
@@ -142,6 +136,7 @@ FocusScope {
             width: visible ? height * 0.8 : 0
 
             enableContextMenu: true
+            contextMenu: navHistPopup
 
             anchors {
                 left: backButton.right
@@ -158,15 +153,7 @@ FocusScope {
                 internal.webview.goForward()
             }
 
-            onShowContextMenu: contextMenu = showNavHistory(internal.webview.navigationHistory.forwardItems, forwardButton)
-
-            Connections {
-                target: forwardButton.contextMenu
-                onNavigate: {
-                    internal.webview.goBackOrForward(offset)
-                    PopupUtils.close(target)
-                }
-            }
+            onShowContextMenu: showNavHistory(internal.webview.navigationHistory.forwardItems, forwardButton)
         }
 
         AddressBar {

--- a/src/app/webcontainer/Chrome.qml
+++ b/src/app/webcontainer/Chrome.qml
@@ -26,6 +26,7 @@ ChromeBase {
     property var webview: null
     property bool navigationButtonsVisible: false
     property bool accountSwitcher: false
+    property real availableHeight
 
     loading: webview && webview.loading && webview.loadProgress !== 100
     loadProgress: loading ? webview.loadProgress : 0
@@ -41,7 +42,22 @@ ChromeBase {
         accountsButton.iconColor = color;
     }
 
+    function showNavHistory(model, caller) {
+        navHistPopup.model = model
+        navHistPopup.show(caller)
+    }
+
     signal chooseAccount()
+
+    NavHistoryPopup {
+        id: navHistPopup
+
+        availHeight: chrome.availableHeight
+        availWidth: chrome.width
+        onNavigate: {
+            chrome.webview.goBackOrForward(offset)
+        }
+    }
 
     FocusScope {
         anchors {
@@ -62,6 +78,9 @@ ChromeBase {
             visible: chrome.navigationButtonsVisible
             width: visible ? height : 0
 
+            enableContextMenu: true
+            contextMenu: navHistPopup
+
             anchors {
                 left: parent.left
                 verticalCenter: parent.verticalCenter
@@ -74,6 +93,8 @@ ChromeBase {
                 }
                 chrome.webview.goBack()
             }
+
+            onShowContextMenu: showNavHistory(chrome.webview.navigationHistory.backItems, backButton)
         }
 
         ChromeButton {
@@ -87,6 +108,9 @@ ChromeBase {
             visible: chrome.navigationButtonsVisible && enabled
             width: visible ? height : 0
 
+            enableContextMenu: true
+            contextMenu: navHistPopup
+
             anchors {
                 left: backButton.right
                 verticalCenter: parent.verticalCenter
@@ -99,6 +123,8 @@ ChromeBase {
                 }
                 chrome.webview.goForward()
             }
+
+            onShowContextMenu: showNavHistory(chrome.webview.navigationHistory.forwardItems, forwardButton)
         }
 
         Item {

--- a/src/app/webcontainer/WebApp.qml
+++ b/src/app/webcontainer/WebApp.qml
@@ -304,6 +304,7 @@ Common.BrowserView {
                     }
                     height: (state === "hidden") ? 0 : units.gu(6)
                     y: webapp.currentWebview ? containerWebView.currentWebview.locationBarController.offset : 0
+                    availableHeight: containerWebView.height
 
                     onChooseAccount: webapp.chooseAccount()
                 }


### PR DESCRIPTION
Press-and-hold and right-click on the back and forward buttons will open a popup with the navigation history just like on other browsers. Currently, it uses `Popover` with custom background color since it doesn't "popup" enough on white contents which websites usually are. I will try to use Popup/Menu from QQC2 and see if it looks better.

This is an expansion of the initial effort in #428 . @lduboeuf  and I already talked about this :smiley: 