### PR TITLE
Fix some tab previews are not visible in 5.12

### DIFF
--- a/src/app/webbrowser/BrowserTab.qml
+++ b/src/app/webbrowser/BrowserTab.qml
@@ -49,13 +49,18 @@ FocusScope {
                                                 webview.height*Screen.devicePixelRatio) : Qt.size(0,0)
     readonly property size previewThumbnailSize: webview ? Qt.size(webview.width/1.5,
                                                          webview.height/1.5) : Qt.size(0,0)
-    //store reference to preview to avoid clearing by garbage collector
-    property var previewCache
+
     visible: false
 
     // Used as a workaround for https://launchpad.net/bugs/1502675 :
     // invoke this on a tab shortly before it is set current.
     signal aboutToShow()
+
+    //store preview to avoid clearing by garbage collector
+    Image {
+        source: preview ? preview : ""
+        visible: false
+    }
 
     FaviconFetcher {
         id: faviconFetcher
@@ -186,7 +191,6 @@ FocusScope {
             webview.grabToImage(function(result) {
                 visible = false
                 preview = result.url
-                previewCache = result
             },previewSize);
 
             //save previews to disk for newtabpage and tab during grabbing
@@ -205,7 +209,6 @@ FocusScope {
                 loadingPreview = true
                 webview.grabToImage(function(result) {
                     preview = result.url
-                    previewCache = result
                 },previewSize);
 
                 webview.grabToImage(function(result) {


### PR DESCRIPTION
This should fix https://github.com/ubports/morph-browser/issues/457