### PR TITLE
Bring back the apparmor confinement check.

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Qt5Widgets REQUIRED)
 #find_package(Qt5WebEngine REQUIRED)
 
 include(FindPkgConfig)
+pkg_check_modules(LIBAPPARMOR libapparmor REQUIRED)
 
 configure_file(
     config.h.in

--- a/src/app/browserapplication.cpp
+++ b/src/app/browserapplication.cpp
@@ -19,6 +19,7 @@
 // system
 #include <cerrno>
 #include <cstring>
+#include <sys/apparmor.h>
 
 // Qtlangc
 #include <QtCore/QMetaObject>
@@ -166,7 +167,6 @@ bool BrowserApplication::initialize(const QString& qmlFileSubPath
     bool runningConfined = true;
     char* label;
     char* mode;
-    /*
     if (aa_getcon(&label, &mode) != -1) {
         if (strcmp(label, "unconfined") == 0) {
             runningConfined = false;
@@ -175,8 +175,6 @@ bool BrowserApplication::initialize(const QString& qmlFileSubPath
     } else if (errno == EINVAL) {
         runningConfined = false;
     }
-    */
-    runningConfined = false;
 
     QString devtoolsPort = inspectorPort();
     QString devtoolsHost = inspectorHost();


### PR DESCRIPTION
When switching to QtWebEngine, the use of libapparmor to get the confinement
profile was commented out. Re-enable this check so we can properly determine
if we are running unconfined.