### PR TITLE
Update MorphSharedWebContext.qml

### DIFF
--- a/src/Morph/Web/MorphSharedWebContext.qml
+++ b/src/Morph/Web/MorphSharedWebContext.qml
@@ -27,7 +27,7 @@ QtObject {
     property QtObject sharedContext: Morph.WebContext {
         id: context
         offTheRecord: false
-        storageName: "MorphSharedWebContext"
+        storageName: "Default"
     }
 
     property QtObject sharedIncognitoContext: Morph.WebContext {

--- a/src/Morph/Web/MorphSharedWebContext.qml
+++ b/src/Morph/Web/MorphSharedWebContext.qml
@@ -27,6 +27,7 @@ QtObject {
     property QtObject sharedContext: Morph.WebContext {
         id: context
         offTheRecord: false
+        storageName: "MorphSharedWebContext"
     }
 
     property QtObject sharedIncognitoContext: Morph.WebContext {

--- a/src/app/webcontainer/webapp-container.qml
+++ b/src/app/webcontainer/webapp-container.qml
@@ -170,6 +170,7 @@ BrowserWindow {
         onLoaded: {
             var context = item.currentWebview.context;
             context.offTheRecord = false;
+            context.storageName = "WebappContainerContext";
             onlineAccountsController.setupWebcontextForAccount(context);
             item.currentWebview.settings.localContentCanAccessRemoteUrls = localContentCanAccessRemoteUrls;
 

--- a/src/app/webcontainer/webapp-container.qml
+++ b/src/app/webcontainer/webapp-container.qml
@@ -170,7 +170,7 @@ BrowserWindow {
         onLoaded: {
             var context = item.currentWebview.context;
             context.offTheRecord = false;
-            context.storageName = "WebappContainerContext";
+            context.storageName = "Default";
             onlineAccountsController.setupWebcontextForAccount(context);
             item.currentWebview.settings.localContentCanAccessRemoteUrls = localContentCanAccessRemoteUrls;
 


### PR DESCRIPTION
define a storageName for the non-incognito profile.
with QtWebEngine 5.15.2 the browser no longer remembered cookies, e.g. logins (without storageName defined)